### PR TITLE
Refine tab tooltip behavior

### DIFF
--- a/src/renderer/src/components/Tabs/TabsComponent.css
+++ b/src/renderer/src/components/Tabs/TabsComponent.css
@@ -47,6 +47,7 @@
     margin-right: 2px;
     /* タブ間の隙間 */
     cursor: pointer;
+    position: relative;
     background-color: var(--ev-c-gray-3);
     /* 非アクティブタブの背景 */
     color: var(--ev-c-text-2);
@@ -102,6 +103,44 @@
     /* 長いファイル名を省略 */
     margin-right: 8px;
     /* 名前と閉じるボタンの間隔 */
+}
+
+.tab-tooltip {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--ev-c-gray-1);
+    color: var(--ev-c-white);
+    padding: 6px 10px;
+    border-radius: 6px;
+    font-size: 12px;
+    max-width: 480px;
+    white-space: normal;
+    word-break: break-all;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.15s ease, visibility 0.15s ease;
+    z-index: 10;
+}
+
+.tab-tooltip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 6px 6px 0 6px;
+    border-style: solid;
+    border-color: var(--ev-c-gray-1) transparent transparent transparent;
+}
+
+.tab-item:hover .tab-tooltip,
+.tab-item:focus-within .tab-tooltip {
+    opacity: 1;
+    visibility: visible;
 }
 
 .close-tab-btn {

--- a/src/renderer/src/components/Tabs/TabsComponent.tsx
+++ b/src/renderer/src/components/Tabs/TabsComponent.tsx
@@ -33,9 +33,14 @@ const TabsComponent: React.FC<TabsProps> = ({
             key={tab.id}
             className={`tab-item ${tab.id === activeTabId ? 'active' : ''}`}
             onClick={() => onSelectTab(tab.id)}
-            title={tab.filePath || 'Untitled'} // フルパスをツールチップに表示
+            aria-label={tab.filePath ?? tab.fileName}
           >
             <span className="tab-name">{tab.fileName}</span>
+            {tab.filePath && (
+              <span className="tab-tooltip" role="tooltip">
+                {tab.filePath}
+              </span>
+            )}
             {/* 最後のタブ以外、またはタブが複数の場合に閉じるボタンを表示 */}
             {(tabs.length > 1 || tab.filePath !== null) && (
                  <button


### PR DESCRIPTION
### Motivation
- Avoid duplicate tooltips by removing the native `title` attribute which produced overlapping native and custom tooltips. 
- Show a styled, wrapped balloon tooltip for long file paths so full paths are readable. 
- Only display the custom tooltip when a full `tab.filePath` exists to avoid empty tooltips on untitled tabs. 
- Preserve accessibility by providing an `aria-label` fallback for screen readers and keyboard focus.

### Description
- Replace the `title` attribute on the tab element with `aria-label` (`aria-label={tab.filePath ?? tab.fileName}`).
- Conditionally render the custom tooltip element only when `tab.filePath` is present (`{tab.filePath && <span className="tab-tooltip" role="tooltip">...`}).
- Add and adjust CSS for `.tab-tooltip` positioning, arrow, shadow, visibility transitions, and ensure `.tab-item` positioning supports the absolute tooltip.
- Modified files: `src/renderer/src/components/Tabs/TabsComponent.tsx` and `src/renderer/src/components/Tabs/TabsComponent.css`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695244b97274832b92532fef4cb65283)