### PR TITLE
edit mode and yaml support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
+        "@types/js-yaml": "^4.0.9",
         "@types/uuid": "^10.0.0",
+        "js-yaml": "^4.1.1",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -2183,6 +2185,12 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -2628,8 +2636,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -6473,7 +6480,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10779,6 +10785,11 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
+    "@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
+    },
     "@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -11102,8 +11113,7 @@
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-buffer-byte-length": {
       "version": "1.0.2",
@@ -13606,7 +13616,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/uuid": "^10.0.0",
+    "js-yaml": "^4.1.1",
     "uuid": "^11.1.0"
   },
   "overrides": {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
 import { join } from 'path'
 import icon from '../../resources/icon.png?asset'
 import fs from 'fs'
@@ -83,6 +83,45 @@ ipcMain.handle('read-file', (event, filePath) => {
     console.error('Error reading file:', error)
     throw error
   }
+})
+
+// ファイル保存ハンドラー
+ipcMain.handle('save-json-file', async (event, { filePath, defaultPath, content }) => {
+  try {
+    let targetPath = filePath
+    if (!targetPath) {
+      const result = await dialog.showSaveDialog(mainWindow, {
+        defaultPath: defaultPath || 'untitled.json',
+        filters: [
+          { name: 'JSON Files', extensions: ['json'] },
+          { name: 'All Files', extensions: ['*'] }
+        ]
+      })
+      if (result.canceled) return { canceled: true }
+      targetPath = result.filePath
+    }
+    const jsonContent = typeof content === 'string' ? content : JSON.stringify(content, null, 2)
+    fs.writeFileSync(targetPath, jsonContent, 'utf8')
+    return { canceled: false, filePath: targetPath }
+  } catch (error) {
+    console.error('Error saving file:', error)
+    throw error
+  }
+})
+
+// 未保存確認ダイアログ
+ipcMain.handle('show-unsaved-dialog', async (event, { fileName }) => {
+  const result = await dialog.showMessageBox(mainWindow, {
+    type: 'warning',
+    title: '未保存の変更',
+    message: `"${fileName}" に未保存の変更があります。`,
+    detail: '保存せずに閉じますか？',
+    buttons: ['保存', '保存せずに閉じる', 'キャンセル'],
+    defaultId: 0,
+    cancelId: 2,
+    noLink: true
+  })
+  return { response: result.response }
 })
 
 // アプリケーション初期化

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -40,6 +40,13 @@ function createWindow() {
     return { action: 'deny' }
   })
 
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.key === 'f' && (input.control || input.meta) && !input.shift && !input.alt) {
+      mainWindow.webContents.send('show-search')
+      event.preventDefault()
+    }
+  })
+
   // 開発環境と本番環境でのURL/ファイル読み込み
   if (isDev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -101,6 +101,7 @@ ipcMain.handle('save-json-file', async (event, { filePath, defaultPath, content 
         defaultPath: defaultPath || 'untitled.json',
         filters: [
           { name: 'JSON Files', extensions: ['json'] },
+          { name: 'YAML Files', extensions: ['yaml', 'yml'] },
           { name: 'All Files', extensions: ['*'] }
         ]
       })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -33,6 +33,11 @@ const api = {
   },
   showUnsavedDialog: async ({ fileName }) => {
     return await ipcRenderer.invoke('show-unsaved-dialog', { fileName })
+  },
+  onShowSearch: (callback) => {
+    const listener = () => callback()
+    ipcRenderer.on('show-search', listener)
+    return () => ipcRenderer.removeListener('show-search', listener)
   }
 }
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -16,51 +16,60 @@ const api = {
   readFile: async (filePath) => {
     return await ipcRenderer.invoke('read-file', filePath)
   },
-  // handleFileOpen: (callback) => ipcRenderer.on('file-opened', callback), // 古いもの
   handleFilesOpen: (callback) => {
     const listener = (event, filePaths) => callback(event, filePaths)
     ipcRenderer.on('files-opened', listener)
     return () => ipcRenderer.removeListener('files-opened', listener)
   },
-  // ウィンドウタイトルを設定する関数
   setWindowTitle: (filePath) => {
     ipcRenderer.send('set-window-title', filePath)
   },
-  // ファイルのドラッグ&ドロップを処理する専用関数
   handleFileDrop: async (filePath) => {
-    // ファイルパスをメインプロセスに送信し、タイトル更新を要求
     ipcRenderer.send('set-window-title', filePath)
-    // ファイルの内容を読み込む
     return await ipcRenderer.invoke('read-file', filePath)
+  },
+  saveJsonFile: async ({ filePath, defaultPath, content }) => {
+    return await ipcRenderer.invoke('save-json-file', { filePath, defaultPath, content })
+  },
+  showUnsavedDialog: async ({ fileName }) => {
+    return await ipcRenderer.invoke('show-unsaved-dialog', { fileName })
   }
 }
 
-window.addEventListener('dragover', (e) => {
-  e.preventDefault()
-}, true)
+window.addEventListener(
+  'dragover',
+  (e) => {
+    e.preventDefault()
+  },
+  true
+)
 
-window.addEventListener('drop', (e) => {
-  e.preventDefault()
+window.addEventListener(
+  'drop',
+  (e) => {
+    e.preventDefault()
 
-  const files = e.dataTransfer.files
-  const filePaths = []
-  if (files.length > 0) {
-    for (const file of files) {
-      try {
-        const filePath = webUtils.getPathForFile(file)
-        if (filePath) {
-          filePaths.push(filePath)
+    const files = e.dataTransfer.files
+    const filePaths = []
+    if (files.length > 0) {
+      for (const file of files) {
+        try {
+          const filePath = webUtils.getPathForFile(file)
+          if (filePath) {
+            filePaths.push(filePath)
+          }
+        } catch (error) {
+          console.error('Error getting path for file:', error)
         }
-      } catch (error) {
-        console.error('Error getting path for file:', error)
       }
     }
-  }
 
-  if (filePaths.length > 0) {
-    ipcRenderer.send('file-dropped', filePaths)
-  }
-}, true) // キャプチャフェーズで確実に捕捉
+    if (filePaths.length > 0) {
+      ipcRenderer.send('file-dropped', filePaths)
+    }
+  },
+  true
+) // キャプチャフェーズで確実に捕捉
 
 // contextIsolation が有効な場合（推奨）
 if (process.contextIsolated) {

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -335,3 +335,331 @@ tr.object-hdr th {
 .error-panel pre {
   white-space: pre-wrap;
 }
+
+/* 編集モード */
+.editable-cell {
+  cursor: pointer;
+  border-radius: 2px;
+  padding: 0 2px;
+}
+
+.editable-cell:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  outline: 1px dashed rgba(255, 255, 255, 0.3);
+}
+
+.editable-boolean {
+  cursor: pointer;
+}
+
+.editable-boolean:hover {
+  background-color: rgba(86, 156, 214, 0.2);
+}
+
+.editable-input {
+  background: #3c3c3c;
+  color: var(--vscode-editor-foreground);
+  border: 1px solid #007acc;
+  border-radius: 2px;
+  padding: 1px 4px;
+  font-family: inherit;
+  font-size: inherit;
+  min-width: 60px;
+  outline: none;
+}
+
+.editable-input:focus {
+  border-color: #007acc;
+  box-shadow: 0 0 0 1px #007acc;
+}
+
+.key-edit-input {
+  background: #3c3c3c;
+  color: var(--identifier-color);
+  border: 1px solid #007acc;
+  border-radius: 2px;
+  padding: 1px 4px;
+  font-family: inherit;
+  font-size: inherit;
+  min-width: 60px;
+  outline: none;
+  width: 100%;
+}
+
+/* ツールバー */
+.edit-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  background-color: #252526;
+  border-bottom: 1px solid #3c3c3c;
+  flex-shrink: 0;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-btn {
+  padding: 4px 10px;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  background: #333;
+  color: var(--vscode-editor-foreground);
+  cursor: pointer;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.toolbar-btn:hover:not(:disabled) {
+  background: #505050;
+}
+
+.toolbar-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.toolbar-btn.active {
+  background: #094771;
+  border-color: #007acc;
+}
+
+.toolbar-btn.save-btn {
+  background: #0e639c;
+  border-color: #1177bb;
+}
+
+.toolbar-btn.save-btn:hover:not(:disabled) {
+  background: #1177bb;
+}
+
+/* 行操作ボタン */
+.row-actions {
+  border: none !important;
+  width: 28px;
+  min-width: 28px;
+  text-align: center;
+}
+
+.delete-row-btn {
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+tr:hover .delete-row-btn {
+  opacity: 1;
+}
+
+.delete-row-btn:hover {
+  color: #f48771;
+  background: rgba(244, 135, 113, 0.15);
+}
+
+/* 追加行 */
+.add-row-btn {
+  background: none;
+  border: 1px dashed #555;
+  color: #888;
+  cursor: pointer;
+  padding: 3px 10px;
+  font-size: 12px;
+  border-radius: 3px;
+  width: 100%;
+}
+
+.add-row-btn:hover {
+  border-color: #007acc;
+  color: #007acc;
+}
+
+.add-cell {
+  border: none !important;
+}
+
+.add-property-form {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.add-key-input {
+  background: #3c3c3c;
+  color: var(--identifier-color);
+  border: 1px solid #007acc;
+  border-radius: 2px;
+  padding: 2px 6px;
+  font-size: 12px;
+  outline: none;
+}
+
+.add-confirm-btn,
+.add-cancel-btn {
+  padding: 2px 8px;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.add-confirm-btn {
+  background: #0e639c;
+  color: white;
+}
+
+.add-cancel-btn {
+  background: #333;
+  color: var(--vscode-editor-foreground);
+}
+
+/* Dirty marker */
+.dirty-marker {
+  color: #f48771;
+  font-weight: bold;
+  margin-right: 2px;
+}
+
+/* テキストエディタ */
+.text-editor-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.text-editor-toolbar {
+  display: flex;
+  gap: 4px;
+  padding: 4px 8px;
+  background: #252526;
+  border-bottom: 1px solid #3c3c3c;
+}
+
+.text-editor-btn {
+  padding: 4px 10px;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  background: #333;
+  color: var(--vscode-editor-foreground);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.text-editor-btn:hover {
+  background: #505050;
+}
+
+.text-editor-body {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.line-numbers {
+  width: 48px;
+  min-width: 48px;
+  background: #1e1e1e;
+  color: #858585;
+  text-align: right;
+  padding: 4px 8px 4px 0;
+  font-family: 'Consolas', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  overflow: hidden;
+  user-select: none;
+  border-right: 1px solid #3c3c3c;
+}
+
+.line-number {
+  padding-right: 4px;
+}
+
+.text-editor-textarea {
+  flex: 1;
+  background: #1e1e1e;
+  color: var(--vscode-editor-foreground);
+  border: none;
+  outline: none;
+  resize: none;
+  padding: 4px 8px;
+  font-family: 'Consolas', 'Courier New', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  tab-size: 2;
+  overflow: auto;
+}
+
+.text-editor-error {
+  padding: 4px 8px;
+  background: #3c1f1e;
+  color: #f48771;
+  font-size: 12px;
+  border-top: 1px solid #5a1d1d;
+}
+
+/* 検索コンテナをツールバー内に統合 */
+.search-container {
+  display: flex;
+  align-items: center;
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+  z-index: 1000;
+}
+
+.search-container input {
+  margin-right: 2px;
+  padding: 4px 8px;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  line-height: 1.4;
+  background: #3c3c3c;
+  color: var(--vscode-editor-foreground);
+  font-size: 12px;
+  width: 180px;
+}
+
+.search-container button {
+  margin-right: 4px;
+  padding: 4px 8px;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  cursor: pointer;
+  background-color: #333;
+  color: var(--vscode-editor-foreground);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.search-container button:hover:not(:disabled) {
+  background-color: #505050;
+}
+
+.search-container button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* json-view-content flex fix */
+.json-view-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.json-viewer-container {
+  flex: 1;
+  overflow: auto;
+  padding-top: 0;
+}

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -94,6 +94,8 @@ td.index.null::after {
 
 .value.string {
   color: var(--string-color);
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .value.number {
@@ -423,6 +425,27 @@ tr.object-hdr th {
 }
 
 .editable-input:focus {
+  border-color: #007acc;
+  box-shadow: 0 0 0 1px #007acc;
+}
+
+.editable-textarea {
+  background: #3c3c3c;
+  color: var(--vscode-editor-foreground);
+  border: 1px solid #007acc;
+  border-radius: 2px;
+  padding: 2px 4px;
+  font-family: inherit;
+  font-size: inherit;
+  outline: none;
+  resize: both;
+  min-width: 120px;
+  box-sizing: border-box;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.editable-textarea:focus {
   border-color: #007acc;
   box-shadow: 0 0 0 1px #007acc;
 }

--- a/src/renderer/src/App.css
+++ b/src/renderer/src/App.css
@@ -336,6 +336,60 @@ tr.object-hdr th {
   white-space: pre-wrap;
 }
 
+/* 編集アクション（JSONエリア内右上） */
+.edit-actions-overlay {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 3px;
+  padding: 6px 10px;
+  background: linear-gradient(to bottom, var(--vscode-editor-background) 80%, transparent);
+  pointer-events: none;
+}
+
+.floating-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 6px;
+  min-width: 28px;
+  height: 26px;
+  border: 1px solid #3c3c3c;
+  border-radius: 3px;
+  background: #333;
+  color: var(--vscode-editor-foreground);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.floating-btn:hover:not(:disabled) {
+  background: #505050;
+}
+
+.floating-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.floating-btn.save-btn {
+  background: #0e639c;
+  border-color: #1177bb;
+}
+
+.floating-btn.save-btn:hover:not(:disabled) {
+  background: #1177bb;
+}
+
+.floating-separator {
+  width: 1px;
+  height: 18px;
+  background: #555;
+  margin: 0 2px;
+}
+
 /* 編集モード */
 .editable-cell {
   cursor: pointer;
@@ -403,6 +457,19 @@ tr.object-hdr th {
   gap: 4px;
 }
 
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-separator {
+  width: 1px;
+  height: 18px;
+  background: #555;
+  margin: 0 2px;
+}
+
 .toolbar-btn {
   padding: 4px 10px;
   border: 1px solid #3c3c3c;
@@ -412,6 +479,9 @@ tr.object-hdr th {
   cursor: pointer;
   font-size: 12px;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .toolbar-btn:hover:not(:disabled) {
@@ -426,6 +496,12 @@ tr.object-hdr th {
 .toolbar-btn.active {
   background: #094771;
   border-color: #007acc;
+}
+
+.toolbar-btn.icon-btn {
+  padding: 4px 6px;
+  min-width: 28px;
+  height: 26px;
 }
 
 .toolbar-btn.save-btn {
@@ -607,18 +683,30 @@ tr:hover .delete-row-btn {
   border-top: 1px solid #5a1d1d;
 }
 
-/* 検索コンテナをツールバー内に統合 */
+/* 検索オーバーレイ */
+.search-overlay {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 10px;
+  background: linear-gradient(to bottom, var(--vscode-editor-background) 80%, transparent);
+  pointer-events: none;
+}
+
 .search-container {
   display: flex;
   align-items: center;
-  background-color: transparent;
-  padding: 0;
-  border-radius: 0;
-  z-index: 1000;
+  background-color: #252526;
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid #3c3c3c;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  pointer-events: auto;
 }
 
 .search-container input {
-  margin-right: 2px;
   padding: 4px 8px;
   border: 1px solid #3c3c3c;
   border-radius: 3px;
@@ -626,28 +714,52 @@ tr:hover .delete-row-btn {
   background: #3c3c3c;
   color: var(--vscode-editor-foreground);
   font-size: 12px;
-  width: 180px;
+  width: 200px;
 }
 
-.search-container button {
+.search-input-wrapper {
+  position: relative;
+  display: flex;
   margin-right: 4px;
-  padding: 4px 8px;
-  border: 1px solid #3c3c3c;
+}
+
+.search-nav-btn {
+  padding: 3px 8px;
+  border: none;
   border-radius: 3px;
   cursor: pointer;
-  background-color: #333;
+  background: transparent;
   color: var(--vscode-editor-foreground);
   font-size: 12px;
   line-height: 1.4;
+  white-space: nowrap;
 }
 
-.search-container button:hover:not(:disabled) {
+.search-nav-btn:hover:not(:disabled) {
   background-color: #505050;
 }
 
-.search-container button:disabled {
+.search-nav-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.search-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: #999;
+  cursor: pointer;
+  margin-left: 2px;
+}
+
+.search-close-btn:hover {
+  background: #505050;
+  color: var(--vscode-editor-foreground);
 }
 
 /* json-view-content flex fix */

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -4,6 +4,7 @@ import TabsComponent from './components/Tabs/TabsComponent';
 import JsonViewComponent from './components/JsonView/JsonViewComponent';
 import { v4 as uuidv4 } from 'uuid';
 import { setValueByPath, deleteByPath, addPropertyByPath, addArrayItemByPath, renameKeyByPath, applyOperation, invertOperation, getValueByPath } from './components/Cell/CellUtils';
+import { detectFileType, parseContent, serializeData, validateText, defaultFileName, FileType } from './components/Cell/FileUtils';
 
 declare global {
   interface Window {
@@ -49,7 +50,8 @@ export interface TabState {
   isDirty: boolean;
   history: { undo: HistoryEntry[]; redo: HistoryEntry[] };
   viewMode: ViewMode;
-  originalJson: string;
+  fileType: FileType;
+  originalContent: string;
 }
 
 const MAX_HISTORY = 100;
@@ -100,7 +102,8 @@ function App() {
       isDirty: false,
       history: { undo: [], redo: [] },
       viewMode: 'grid',
-      originalJson: data !== null ? JSON.stringify(data, null, 2) : '',
+      fileType: filePath ? detectFileType(filePath) : 'json',
+      originalContent: data !== null ? serializeData(data, filePath ? detectFileType(filePath) : 'json') : '',
     };
     setTabs(prevTabs => [...prevTabs, newTab]);
     if (makeActive || tabs.length === 0) {
@@ -117,23 +120,25 @@ function App() {
     if (!tab || !tab.jsonData) return false;
 
     try {
-      const content = JSON.stringify(tab.jsonData, null, 2);
+      const content = serializeData(tab.jsonData, tab.fileType);
       const result = await window.electron?.saveJsonFile({
         filePath: tab.filePath,
-        defaultPath: tab.fileName || 'untitled.json',
+        defaultPath: tab.fileName || defaultFileName(tab.fileType),
         content
       });
       if (!result || result.canceled) return false;
 
       const newFileName = getFileName(result.filePath);
+      const newFileType = detectFileType(result.filePath);
       setTabs(prevTabs => prevTabs.map(t => {
         if (t.id !== targetId) return t;
         return {
           ...t,
           filePath: result.filePath,
           fileName: newFileName,
+          fileType: newFileType,
           isDirty: false,
-          originalJson: content
+          originalContent: content
         };
       }));
       return true;
@@ -189,9 +194,10 @@ function App() {
         updateTabData(tabId, { jsonData: { error: `Cannot read file outside Electron environment.` }, filePath: filePath, fileName: `Error - ${getFileName(filePath)}` });
         return;
       }
-      const json = JSON.parse(fileContent);
+      const fileType = detectFileType(filePath);
+      const parsed = parseContent(fileContent, fileType);
       const fileName = getFileName(filePath);
-      updateTabData(tabId, { jsonData: json, filePath: filePath, fileName: fileName, originalJson: JSON.stringify(json, null, 2) });
+      updateTabData(tabId, { jsonData: parsed, filePath: filePath, fileName: fileName, fileType: fileType, originalContent: serializeData(parsed, fileType) });
     } catch (error: any) {
       console.error('Error loading file into tab:', filePath, error);
       const fileName = getFileName(filePath);
@@ -313,15 +319,15 @@ function App() {
   const handleTextEditorChange = useCallback((newText: string) => {
     if (!activeTabId) return;
     try {
-      const parsed = JSON.parse(newText);
+      const parsed = validateText(newText, activeTabData?.fileType || 'json');
       setTabs(prevTabs => prevTabs.map(tab => {
         if (tab.id !== activeTabId) return tab;
         return { ...tab, jsonData: parsed, isDirty: true };
       }));
     } catch {
-      // invalid JSON
+      // invalid content
     }
-  }, [activeTabId]);
+  }, [activeTabId, activeTabData]);
 
   // --- 検索関連処理 ---
   const handleSearch = useCallback(() => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ declare global {
       getFilePath: (file: File) => string;
       saveJsonFile: (opts: { filePath?: string | null; defaultPath?: string; content: string }) => Promise<{ canceled: boolean; filePath?: string }>;
       showUnsavedDialog: (opts: { fileName: string }) => Promise<{ response: number }>;
+      onShowSearch: (callback: () => void) => (() => void) | undefined;
       platform?: string;
     }
   }
@@ -56,6 +57,7 @@ const MAX_HISTORY = 100;
 function App() {
   const [tabs, setTabs] = useState<TabState[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
+  const [searchVisible, setSearchVisible] = useState(false);
 
   const getFileName = (path: string | null): string => {
     if (!path) return 'Untitled';
@@ -70,6 +72,17 @@ function App() {
       return 'Untitled';
     }
   };
+
+  const updateTabData = useCallback((tabId: string, updates: Partial<Omit<TabState, 'id'>>) => {
+    setTabs(prevTabs =>
+      prevTabs.map(tab =>
+        tab.id === tabId ? { ...tab, ...updates } : tab
+      )
+    );
+  }, []);
+
+  // --- アクティブなタブの取得 ---
+  const activeTabData = tabs.find(tab => tab.id === activeTabId);
 
   // --- タブ操作 ---
   const addTab = useCallback((filePath: string | null = null, data: any = null, makeActive = true): string => {
@@ -95,6 +108,40 @@ function App() {
     }
     return newTabId;
   }, [tabs.length]);
+
+  // --- 保存 ---
+  const handleSave = useCallback(async (tabId?: string): Promise<boolean> => {
+    const targetId = tabId || activeTabId;
+    if (!targetId) return false;
+    const tab = tabs.find(t => t.id === targetId);
+    if (!tab || !tab.jsonData) return false;
+
+    try {
+      const content = JSON.stringify(tab.jsonData, null, 2);
+      const result = await window.electron?.saveJsonFile({
+        filePath: tab.filePath,
+        defaultPath: tab.fileName || 'untitled.json',
+        content
+      });
+      if (!result || result.canceled) return false;
+
+      const newFileName = getFileName(result.filePath);
+      setTabs(prevTabs => prevTabs.map(t => {
+        if (t.id !== targetId) return t;
+        return {
+          ...t,
+          filePath: result.filePath,
+          fileName: newFileName,
+          isDirty: false,
+          originalJson: content
+        };
+      }));
+      return true;
+    } catch (error) {
+      console.error('Error saving file:', error);
+      return false;
+    }
+  }, [tabs, activeTabId]);
 
   const closeTabWithCheck = useCallback(async (tabIdToClose: string) => {
     const tab = tabs.find(t => t.id === tabIdToClose);
@@ -124,15 +171,7 @@ function App() {
       }
       return newTabs;
     });
-  }, [tabs, activeTabId]);
-
-  const updateTabData = useCallback((tabId: string, updates: Partial<Omit<TabState, 'id'>>) => {
-    setTabs(prevTabs =>
-      prevTabs.map(tab =>
-        tab.id === tabId ? { ...tab, ...updates } : tab
-      )
-    );
-  }, []);
+  }, [tabs, activeTabId, handleSave]);
 
   // --- ファイル処理 ---
   const loadFileIntoTab = useCallback(async (filePath: string, tabId: string) => {
@@ -183,14 +222,6 @@ function App() {
   }, [activeTabId]);
 
   // --- Undo/Redo ---
-  const pushHistory = useCallback((tabId: string, entry: HistoryEntry) => {
-    setTabs(prevTabs => prevTabs.map(tab => {
-      if (tab.id !== tabId) return tab;
-      const undo = [entry, ...tab.history.undo].slice(0, MAX_HISTORY);
-      return { ...tab, history: { undo, redo: [] }, isDirty: true };
-    }));
-  }, []);
-
   const handleUndo = useCallback(() => {
     if (!activeTabId) return;
     setTabs(prevTabs => prevTabs.map(tab => {
@@ -279,40 +310,6 @@ function App() {
     }));
   }, [activeTabId]);
 
-  // --- 保存 ---
-  const handleSave = useCallback(async (tabId?: string): Promise<boolean> => {
-    const targetId = tabId || activeTabId;
-    if (!targetId) return false;
-    const tab = tabs.find(t => t.id === targetId);
-    if (!tab || !tab.jsonData) return false;
-
-    try {
-      const content = JSON.stringify(tab.jsonData, null, 2);
-      const result = await window.electron?.saveJsonFile({
-        filePath: tab.filePath,
-        defaultPath: tab.fileName || 'untitled.json',
-        content
-      });
-      if (!result || result.canceled) return false;
-
-      const newFileName = getFileName(result.filePath);
-      setTabs(prevTabs => prevTabs.map(t => {
-        if (t.id !== targetId) return t;
-        return {
-          ...t,
-          filePath: result.filePath,
-          fileName: newFileName,
-          isDirty: false,
-          originalJson: content
-        };
-      }));
-      return true;
-    } catch (error) {
-      console.error('Error saving file:', error);
-      return false;
-    }
-  }, [tabs, activeTabId]);
-
   const handleTextEditorChange = useCallback((newText: string) => {
     if (!activeTabId) return;
     try {
@@ -322,9 +319,43 @@ function App() {
         return { ...tab, jsonData: parsed, isDirty: true };
       }));
     } catch {
-      // invalid JSON - ignore parse errors in text mode
+      // invalid JSON
     }
   }, [activeTabId]);
+
+  // --- 検索関連処理 ---
+  const handleSearch = useCallback(() => {
+    if (!activeTabData) return;
+    const results = searchJson(activeTabData.jsonData, activeTabData.searchQuery);
+    updateTabData(activeTabData.id, { searchResults: results, currentResultIndex: results.length > 0 ? 0 : -1 });
+  }, [activeTabData, updateTabData]);
+
+  const handleNextResult = useCallback(() => {
+    if (!activeTabData || activeTabData.searchResults.length === 0) return;
+    const nextIndex = (activeTabData.currentResultIndex + 1) % activeTabData.searchResults.length;
+    updateTabData(activeTabData.id, { currentResultIndex: nextIndex });
+  }, [activeTabData, updateTabData]);
+
+  const clearSearch = useCallback(() => {
+    if (!activeTabData) return;
+    updateTabData(activeTabData.id, { searchQuery: '', searchResults: [], currentResultIndex: -1 });
+  }, [activeTabData, updateTabData]);
+
+  const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!activeTabData) return;
+    const query = e.target.value;
+    updateTabData(activeTabData.id, { searchQuery: query, searchResults: [], currentResultIndex: -1 });
+  }, [activeTabData, updateTabData]);
+
+  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.nativeEvent.isComposing || e.key !== 'Enter') return;
+    if (!activeTabData || !activeTabData.searchQuery) return;
+    if (activeTabData.searchResults.length > 0) {
+      handleNextResult();
+    } else {
+      handleSearch();
+    }
+  }, [activeTabData, handleSearch, handleNextResult]);
 
   // --- 初期化とイベントリスナー ---
   useEffect(() => {
@@ -367,11 +398,21 @@ function App() {
       });
     }
 
+    let removeShowSearchListener: (() => void) | undefined;
+    if (window.electron?.onShowSearch) {
+      removeShowSearchListener = window.electron.onShowSearch(() => {
+        setSearchVisible(true);
+      });
+    }
+
     return () => {
       document.removeEventListener('dragover', handleDragOver);
       document.removeEventListener('drop', handleDrop);
       if (removeFilesOpenListener && typeof removeFilesOpenListener === 'function') {
         removeFilesOpenListener();
+      }
+      if (removeShowSearchListener) {
+        removeShowSearchListener();
       }
     };
   }, [addTab, handleDrop, loadFileIntoTab, tabs]);
@@ -384,11 +425,7 @@ function App() {
 
       if (mod && e.key === 's') {
         e.preventDefault();
-        if (e.shiftKey) {
-          handleSave();
-        } else {
-          handleSave();
-        }
+        handleSave();
       }
       if (mod && e.key === 'z' && !e.shiftKey) {
         e.preventDefault();
@@ -402,11 +439,19 @@ function App() {
         e.preventDefault();
         handleRedo();
       }
+      if (mod && e.key === 'f') {
+        e.preventDefault();
+        setSearchVisible(true);
+      }
+      if (e.key === 'Escape' && searchVisible) {
+        setSearchVisible(false);
+        clearSearch();
+      }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [handleSave, handleUndo, handleRedo]);
+  }, [handleSave, handleUndo, handleRedo, searchVisible, clearSearch]);
 
   // --- ウィンドウタイトル更新 ---
   useEffect(() => {
@@ -418,43 +463,6 @@ function App() {
     }
   }, [activeTabId, tabs]);
 
-  // --- アクティブなタブの取得 ---
-  const activeTabData = tabs.find(tab => tab.id === activeTabId);
-
-  // --- 検索関連処理 ---
-  const handleSearch = useCallback(() => {
-    if (!activeTabData) return;
-    const results = searchJson(activeTabData.jsonData, activeTabData.searchQuery);
-    updateTabData(activeTabData.id, { searchResults: results, currentResultIndex: results.length > 0 ? 0 : -1 });
-  }, [activeTabData, updateTabData]);
-
-  const handleNextResult = useCallback(() => {
-    if (!activeTabData || activeTabData.searchResults.length === 0) return;
-    const nextIndex = (activeTabData.currentResultIndex + 1) % activeTabData.searchResults.length;
-    updateTabData(activeTabData.id, { currentResultIndex: nextIndex });
-  }, [activeTabData, updateTabData]);
-
-  const clearSearch = useCallback(() => {
-    if (!activeTabData) return;
-    updateTabData(activeTabData.id, { searchQuery: '', searchResults: [], currentResultIndex: -1 });
-  }, [activeTabData, updateTabData]);
-
-  const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!activeTabData) return;
-    const query = e.target.value;
-    updateTabData(activeTabData.id, { searchQuery: query, searchResults: [], currentResultIndex: -1 });
-  }, [activeTabData, updateTabData]);
-
-  const handleSearchKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.nativeEvent.isComposing || e.key !== 'Enter') return;
-    if (!activeTabData || !activeTabData.searchQuery) return;
-    if (activeTabData.searchResults.length > 0) {
-      handleNextResult();
-    } else {
-      handleSearch();
-    }
-  }, [activeTabData, handleSearch, handleNextResult]);
-
   // --- レンダリング ---
   return (
     <div className="app-container vscode-dark">
@@ -464,12 +472,18 @@ function App() {
         onSelectTab={setActiveTabId}
         onCloseTab={closeTabWithCheck}
         onAddTab={() => addTab(null, null, true)}
+        onToggleEditMode={toggleEditMode}
+        onToggleViewMode={toggleViewMode}
+        activeTabMode={activeTabData?.mode || 'view'}
+        activeTabViewMode={activeTabData?.viewMode || 'grid'}
       />
       <div className="json-view-area">
         {activeTabData ? (
           <JsonViewComponent
             key={activeTabData.id}
             tabData={activeTabData}
+            searchVisible={searchVisible}
+            onSearchVisibleChange={setSearchVisible}
             onSearchInputChange={handleSearchInputChange}
             onSearchKeyDown={handleSearchKeyDown}
             onSearchExecute={handleSearch}
@@ -480,8 +494,6 @@ function App() {
             onAddProperty={handleAddProperty}
             onAddArrayItem={handleAddArrayItem}
             onRenameKey={handleRenameKey}
-            onToggleEditMode={toggleEditMode}
-            onToggleViewMode={toggleViewMode}
             onSave={() => handleSave()}
             onUndo={handleUndo}
             onRedo={handleRedo}

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,61 +1,80 @@
 import React, { useState, useEffect, useCallback } from 'react';
-// import Cell from './components/Cell/Cell'; // JsonViewComponent に移動
 import './App.css';
-import TabsComponent from './components/Tabs/TabsComponent'; // 新規
-import JsonViewComponent from './components/JsonView/JsonViewComponent'; // 新規
-import { v4 as uuidv4 } from 'uuid'; // ID生成用
+import TabsComponent from './components/Tabs/TabsComponent';
+import JsonViewComponent from './components/JsonView/JsonViewComponent';
+import { v4 as uuidv4 } from 'uuid';
+import { setValueByPath, deleteByPath, addPropertyByPath, addArrayItemByPath, renameKeyByPath, applyOperation, invertOperation, getValueByPath } from './components/Cell/CellUtils';
 
 declare global {
   interface Window {
     electron: {
-      handleFilesOpen: (callback: (event: any, filePaths: string[]) => void) => (() => void) | undefined; // 修正：複数ファイル対応、戻り値の型
+      handleFilesOpen: (callback: (event: any, filePaths: string[]) => void) => (() => void) | undefined;
       readFile: (filePath: string) => Promise<string>;
-      setWindowTitle: (filePath: string | null) => void; // タイトル設定用の型を追加
-      handleFileDrop: (filePath: string) => Promise<string>; // 新しいメソッドの型を追加
-      getFilePath: (file: File) => string; // 新規追加：Fileオブジェクトからパスを取得
-      platform?: string; // platformプロパティを追加（オプション）
-      // 必要ならリスナー削除用の関数も追加
+      setWindowTitle: (filePath: string | null) => void;
+      handleFileDrop: (filePath: string) => Promise<string>;
+      getFilePath: (file: File) => string;
+      saveJsonFile: (opts: { filePath?: string | null; defaultPath?: string; content: string }) => Promise<{ canceled: boolean; filePath?: string }>;
+      showUnsavedDialog: (opts: { fileName: string }) => Promise<{ response: number }>;
+      platform?: string;
     }
   }
 }
 
-// TabState インターフェースの定義
-export interface TabState { // export して JsonViewComponent でも使えるようにする
+export type ViewMode = 'grid' | 'text'
+export type EditMode = 'view' | 'edit'
+
+export interface HistoryEntry {
+  op: DataOperation
+  inverseOp: DataOperation
+}
+
+export interface DataOperation {
+  type: 'set' | 'delete' | 'add' | 'rename'
+  path: string
+  value?: any
+  key?: string
+  newKey?: string
+}
+
+export interface TabState {
   id: string;
   filePath: string | null;
-  fileName: string; // 表示用
+  fileName: string;
   jsonData: any;
   searchQuery: string;
   searchResults: Array<{ path: string; value: any }>;
   currentResultIndex: number;
-  // 必要ならスクロール位置なども保存
+  mode: EditMode;
+  isDirty: boolean;
+  history: { undo: HistoryEntry[]; redo: HistoryEntry[] };
+  viewMode: ViewMode;
+  originalJson: string;
 }
+
+const MAX_HISTORY = 100;
 
 function App() {
   const [tabs, setTabs] = useState<TabState[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | null>(null);
 
+  const getFileName = (path: string | null): string => {
+    if (!path) return 'Untitled';
+    try {
+      if (window.electron?.platform) {
+        const separator = window.electron.platform === 'win32' ? '\\' : '/';
+        return path.substring(path.lastIndexOf(separator) + 1);
+      }
+      return path.substring(path.lastIndexOf('/') + 1);
+    } catch (e) {
+      console.error("Error getting file name:", e);
+      return 'Untitled';
+    }
+  };
+
   // --- タブ操作 ---
   const addTab = useCallback((filePath: string | null = null, data: any = null, makeActive = true): string => {
     const newTabId = uuidv4();
-    // ファイル名取得ロジックを安全に
-    const getFileName = (path: string | null): string => {
-      if (!path) return 'Untitled';
-      try {
-        // Electron環境かどうか、プラットフォームは何かを考慮
-        if (window.electron?.platform) {
-          const separator = window.electron.platform === 'win32' ? '\\' : '/';
-          return path.substring(path.lastIndexOf(separator) + 1);
-        }
-        // ブラウザなどElectron環境外の場合（フォールバック）
-        return path.substring(path.lastIndexOf('/') + 1);
-      } catch (e) {
-        console.error("Error getting file name:", e);
-        return 'Untitled';
-      }
-    };
     const fileName = getFileName(filePath);
-
     const newTab: TabState = {
       id: newTabId,
       filePath: filePath,
@@ -63,37 +82,49 @@ function App() {
       jsonData: data,
       searchQuery: '',
       searchResults: [],
-      currentResultIndex: -1, // 初期値は -1 が適切
+      currentResultIndex: -1,
+      mode: 'view',
+      isDirty: false,
+      history: { undo: [], redo: [] },
+      viewMode: 'grid',
+      originalJson: data !== null ? JSON.stringify(data, null, 2) : '',
     };
     setTabs(prevTabs => [...prevTabs, newTab]);
-    if (makeActive || tabs.length === 0) { // 最初のタブもアクティブにする
+    if (makeActive || tabs.length === 0) {
       setActiveTabId(newTabId);
     }
     return newTabId;
-  }, [tabs.length]); // tabs.length を依存配列に追加
+  }, [tabs.length]);
 
-  const closeTab = useCallback((tabIdToClose: string) => {
+  const closeTabWithCheck = useCallback(async (tabIdToClose: string) => {
+    const tab = tabs.find(t => t.id === tabIdToClose);
+    if (!tab) return;
+
+    if (tab.isDirty && window.electron?.showUnsavedDialog) {
+      const result = await window.electron.showUnsavedDialog({ fileName: tab.fileName });
+      if (result.response === 0) {
+        const saved = await handleSave(tabIdToClose);
+        if (!saved) return;
+      } else if (result.response === 2) {
+        return;
+      }
+    }
+
     setTabs(prevTabs => {
-      const indexToClose = prevTabs.findIndex(tab => tab.id === tabIdToClose);
+      const indexToClose = prevTabs.findIndex(t => t.id === tabIdToClose);
       if (indexToClose === -1) return prevTabs;
-
-      const newTabs = prevTabs.filter(tab => tab.id !== tabIdToClose);
-
+      const newTabs = prevTabs.filter(t => t.id !== tabIdToClose);
       if (activeTabId === tabIdToClose) {
         if (newTabs.length === 0) {
           setActiveTabId(null);
-          // オプション：最後のタブを閉じたら新しい空タブを追加する
-          // addTab(null, null, true);
         } else {
-          // 隣接するタブ（優先的に前、なければ後ろ）をアクティブにする
-          const newActiveIndex = Math.max(0, indexToClose -1); // 前のタブ
-          const nextActiveIndex = indexToClose < newTabs.length ? indexToClose : newTabs.length - 1; // 閉じた位置 or 最後のタブ
-          setActiveTabId(newTabs[newActiveIndex < newTabs.length ? newActiveIndex : nextActiveIndex]?.id || null);
+          const newActiveIndex = Math.max(0, indexToClose - 1);
+          setActiveTabId(newTabs[newActiveIndex < newTabs.length ? newActiveIndex : newTabs.length - 1]?.id || null);
         }
       }
       return newTabs;
     });
-  }, [activeTabId]); // addTab は依存関係から削除
+  }, [tabs, activeTabId]);
 
   const updateTabData = useCallback((tabId: string, updates: Partial<Omit<TabState, 'id'>>) => {
     setTabs(prevTabs =>
@@ -103,16 +134,13 @@ function App() {
     );
   }, []);
 
-
   // --- ファイル処理 ---
   const loadFileIntoTab = useCallback(async (filePath: string, tabId: string) => {
-     // 既に読み込み済み、または読み込み中の場合はスキップ（オプション）
-     const existingTab = tabs.find(t => t.id === tabId);
-     if (existingTab && existingTab.jsonData) {
-         console.log(`Tab ${tabId} already has data for ${filePath}`);
-         return;
-     }
-
+    const existingTab = tabs.find(t => t.id === tabId);
+    if (existingTab && existingTab.jsonData) {
+      console.log(`Tab ${tabId} already has data for ${filePath}`);
+      return;
+    }
     try {
       let fileContent;
       if (window.electron && window.electron.readFile) {
@@ -122,48 +150,186 @@ function App() {
         updateTabData(tabId, { jsonData: { error: `Cannot read file outside Electron environment.` }, filePath: filePath, fileName: `Error - ${getFileName(filePath)}` });
         return;
       }
-
       const json = JSON.parse(fileContent);
-      const fileName = getFileName(filePath); // ファイル名を再取得（念のため）
-      updateTabData(tabId, { jsonData: json, filePath: filePath, fileName: fileName });
-
+      const fileName = getFileName(filePath);
+      updateTabData(tabId, { jsonData: json, filePath: filePath, fileName: fileName, originalJson: JSON.stringify(json, null, 2) });
     } catch (error: any) {
       console.error('Error loading file into tab:', filePath, error);
       const fileName = getFileName(filePath);
       updateTabData(tabId, { jsonData: { error: `Failed to load or parse: ${error.message || error}` }, filePath: filePath, fileName: `Error - ${fileName}` });
     }
-  }, [updateTabData, tabs]); // tabs を依存関係に追加
-
-   // ファイル名取得ヘルパー（useCallbackの外で定義しても良い）
-   const getFileName = (path: string | null): string => {
-     if (!path) return 'Untitled';
-     try {
-       if (window.electron?.platform) {
-         const separator = window.electron.platform === 'win32' ? '\\' : '/';
-         return path.substring(path.lastIndexOf(separator) + 1);
-       }
-       return path.substring(path.lastIndexOf('/') + 1);
-     } catch (e) {
-       console.error("Error getting file name:", e);
-       return 'Untitled';
-     }
-   };
+  }, [updateTabData, tabs]);
 
   const handleDrop = useCallback(async (e: DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
-
-    // ファイルの処理はPreloadスクリプトが行い、メインプロセス経由で渡されるため、
-    // ここではイベントの伝播を止めるだけでよい。
-    // e.dataTransfer.files からの読み込みは ContextBridge の制限で失敗するため削除。
   }, []);
 
+  // --- 編集モード切替 ---
+  const toggleEditMode = useCallback(() => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      return { ...tab, mode: tab.mode === 'view' ? 'edit' : 'view' };
+    }));
+  }, [activeTabId]);
+
+  const toggleViewMode = useCallback(() => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      return { ...tab, viewMode: tab.viewMode === 'grid' ? 'text' : 'grid' };
+    }));
+  }, [activeTabId]);
+
+  // --- Undo/Redo ---
+  const pushHistory = useCallback((tabId: string, entry: HistoryEntry) => {
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== tabId) return tab;
+      const undo = [entry, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, history: { undo, redo: [] }, isDirty: true };
+    }));
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId || tab.history.undo.length === 0) return tab;
+      const [latest, ...restUndo] = tab.history.undo;
+      const newJson = applyOperation(tab.jsonData, latest.inverseOp);
+      const redo = [latest, ...tab.history.redo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo: restUndo, redo }, isDirty: restUndo.length > 0 };
+    }));
+  }, [activeTabId]);
+
+  const handleRedo = useCallback(() => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId || tab.history.redo.length === 0) return tab;
+      const [latest, ...restRedo] = tab.history.redo;
+      const newJson = applyOperation(tab.jsonData, latest.op);
+      const undo = [latest, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo, redo: restRedo }, isDirty: true };
+    }));
+  }, [activeTabId]);
+
+  // --- データ変更ハンドラ ---
+  const handleDataChange = useCallback((path: string, newValue: any) => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      const op: DataOperation = { type: 'set', path, value: newValue };
+      const inverseOp = invertOperation(tab.jsonData, op);
+      const newJson = applyOperation(tab.jsonData, op);
+      const undo = [{ op, inverseOp }, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo, redo: [] }, isDirty: true };
+    }));
+  }, [activeTabId]);
+
+  const handleDelete = useCallback((path: string) => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      const op: DataOperation = { type: 'delete', path };
+      const inverseOp = invertOperation(tab.jsonData, op);
+      const newJson = applyOperation(tab.jsonData, op);
+      const undo = [{ op, inverseOp }, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo, redo: [] }, isDirty: true };
+    }));
+  }, [activeTabId]);
+
+  const handleAddProperty = useCallback((path: string, key: string, value: any) => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      const target = path ? getValueByPath(tab.jsonData, path) : tab.jsonData;
+      if (!target || typeof target !== 'object' || Array.isArray(target)) return tab;
+      const newTarget = { ...target, [key]: value };
+      const newJson = path ? setValueByPath(tab.jsonData, path, newTarget) : newTarget;
+      const op: DataOperation = { type: 'add', path, key, value };
+      const inverseOp: DataOperation = { type: 'delete', path: path ? `${path}.${key}` : `.${key}` };
+      const undo = [{ op, inverseOp }, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo, redo: [] }, isDirty: true };
+    }));
+  }, [activeTabId]);
+
+  const handleAddArrayItem = useCallback((path: string, value: any) => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      const newJson = addArrayItemByPath(tab.jsonData, path, value);
+      const op: DataOperation = { type: 'add', path, value };
+      const target = path ? getValueByPath(tab.jsonData, path) : tab.jsonData;
+      const idx = Array.isArray(target) ? target.length : 0;
+      const inverseOp: DataOperation = { type: 'delete', path: `${path}[${idx}]` };
+      const undo = [{ op, inverseOp }, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo, redo: [] }, isDirty: true };
+    }));
+  }, [activeTabId]);
+
+  const handleRenameKey = useCallback((path: string, oldKey: string, newKey: string) => {
+    if (!activeTabId) return;
+    setTabs(prevTabs => prevTabs.map(tab => {
+      if (tab.id !== activeTabId) return tab;
+      const newJson = renameKeyByPath(tab.jsonData, path, oldKey, newKey);
+      const op: DataOperation = { type: 'rename', path, key: oldKey, newKey };
+      const inverseOp: DataOperation = { type: 'rename', path, key: newKey, newKey: oldKey };
+      const undo = [{ op, inverseOp }, ...tab.history.undo].slice(0, MAX_HISTORY);
+      return { ...tab, jsonData: newJson, history: { undo, redo: [] }, isDirty: true };
+    }));
+  }, [activeTabId]);
+
+  // --- 保存 ---
+  const handleSave = useCallback(async (tabId?: string): Promise<boolean> => {
+    const targetId = tabId || activeTabId;
+    if (!targetId) return false;
+    const tab = tabs.find(t => t.id === targetId);
+    if (!tab || !tab.jsonData) return false;
+
+    try {
+      const content = JSON.stringify(tab.jsonData, null, 2);
+      const result = await window.electron?.saveJsonFile({
+        filePath: tab.filePath,
+        defaultPath: tab.fileName || 'untitled.json',
+        content
+      });
+      if (!result || result.canceled) return false;
+
+      const newFileName = getFileName(result.filePath);
+      setTabs(prevTabs => prevTabs.map(t => {
+        if (t.id !== targetId) return t;
+        return {
+          ...t,
+          filePath: result.filePath,
+          fileName: newFileName,
+          isDirty: false,
+          originalJson: content
+        };
+      }));
+      return true;
+    } catch (error) {
+      console.error('Error saving file:', error);
+      return false;
+    }
+  }, [tabs, activeTabId]);
+
+  const handleTextEditorChange = useCallback((newText: string) => {
+    if (!activeTabId) return;
+    try {
+      const parsed = JSON.parse(newText);
+      setTabs(prevTabs => prevTabs.map(tab => {
+        if (tab.id !== activeTabId) return tab;
+        return { ...tab, jsonData: parsed, isDirty: true };
+      }));
+    } catch {
+      // invalid JSON - ignore parse errors in text mode
+    }
+  }, [activeTabId]);
 
   // --- 初期化とイベントリスナー ---
-   useEffect(() => {
-    // 初期タブ（空のタブ）
+  useEffect(() => {
     if (tabs.length === 0) {
-       addTab(null, null, true);
+      addTab(null, null, true);
     }
 
     const handleDragOver = (e: DragEvent) => {
@@ -171,64 +337,92 @@ function App() {
       e.stopPropagation();
     };
 
-     // document 全体で drag/drop を受け付ける
-     document.addEventListener('dragover', handleDragOver);
-     document.addEventListener('drop', handleDrop);
+    document.addEventListener('dragover', handleDragOver);
+    document.addEventListener('drop', handleDrop);
 
-     // file-opened イベント（アプリ起動時やDockからのファイルオープン）
-     let removeFilesOpenListener: (() => void) | undefined;
-     if (window.electron?.handleFilesOpen) {
-         removeFilesOpenListener = window.electron.handleFilesOpen((event, filePaths) => {
-             console.log('Files opened via event:', filePaths);
-             filePaths.forEach((filePath, index) => {
-                 // 既に開いているタブがないか確認（オプション）
-                 const existingTab = tabs.find(tab => tab.filePath === filePath);
-                 if (existingTab) {
-                     setActiveTabId(existingTab.id); // 既存タブをアクティブにする
-                     if (index === 0) { /* only log once */ console.log(`Tab for ${filePath} already exists.`); }
-                 } else {
-                     // 最初のファイルで、かつ現在のタブが1つだけで未読み込みのUntitledだった場合、上書きする
-                     if (index === 0 && tabs.length === 1 && tabs[0].filePath === null && tabs[0].jsonData === null) {
-                         const targetTabId = tabs[0].id;
-                         loadFileIntoTab(filePath, targetTabId);
-                         setActiveTabId(targetTabId);
-                     } else {
-                         const makeActive = index === 0; // 最初のファイルだけアクティブにする
-                         const newTabId = addTab(filePath, null, makeActive);
-                         loadFileIntoTab(filePath, newTabId);
-                     }
-                 }
-             });
-         });
-     }
+    let removeFilesOpenListener: (() => void) | undefined;
+    if (window.electron?.handleFilesOpen) {
+      removeFilesOpenListener = window.electron.handleFilesOpen((event, filePaths) => {
+        console.log('Files opened via event:', filePaths);
+        filePaths.forEach((filePath, index) => {
+          const existingTab = tabs.find(tab => tab.filePath === filePath);
+          if (existingTab) {
+            setActiveTabId(existingTab.id);
+            if (index === 0) { console.log(`Tab for ${filePath} already exists.`); }
+          } else {
+            const isFirstFile = index === 0;
+            const emptyUntitled = tabs.find(t =>
+              t.filePath === null && t.jsonData === null && !t.isDirty
+            );
+            if (isFirstFile && emptyUntitled) {
+              loadFileIntoTab(filePath, emptyUntitled.id);
+              setActiveTabId(emptyUntitled.id);
+            } else {
+              const makeActive = index === 0;
+              const newTabId = addTab(filePath, null, makeActive);
+              loadFileIntoTab(filePath, newTabId);
+            }
+          }
+        });
+      });
+    }
 
     return () => {
       document.removeEventListener('dragover', handleDragOver);
       document.removeEventListener('drop', handleDrop);
-      // クリーンアップ関数を呼ぶ
       if (removeFilesOpenListener && typeof removeFilesOpenListener === 'function') {
         removeFilesOpenListener();
       }
     };
-   }, [addTab, handleDrop, loadFileIntoTab, tabs]); // tabs を依存配列に追加（既存タブチェックのため）
+  }, [addTab, handleDrop, loadFileIntoTab, tabs]);
+
+  // --- キーボードショートカット ---
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.nativeEvent.isComposing) return;
+      const mod = e.ctrlKey || e.metaKey;
+
+      if (mod && e.key === 's') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          handleSave();
+        } else {
+          handleSave();
+        }
+      }
+      if (mod && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        handleUndo();
+      }
+      if (mod && e.key === 'z' && e.shiftKey) {
+        e.preventDefault();
+        handleRedo();
+      }
+      if (mod && e.key === 'y') {
+        e.preventDefault();
+        handleRedo();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleSave, handleUndo, handleRedo]);
 
   // --- ウィンドウタイトル更新 ---
   useEffect(() => {
     const activeTab = tabs.find(tab => tab.id === activeTabId);
-    // main プロセスに filePath を渡してタイトルを設定してもらう
     if (window.electron?.setWindowTitle) {
       window.electron.setWindowTitle(activeTab?.filePath ?? null);
     } else {
-        // Electron外の場合のフォールバック
-        document.title = activeTab ? activeTab.fileName : 'JSON Grid Viewer';
+      document.title = activeTab ? activeTab.fileName : 'JSON Grid Viewer';
     }
   }, [activeTabId, tabs]);
 
   // --- アクティブなタブの取得 ---
   const activeTabData = tabs.find(tab => tab.id === activeTabId);
 
-  // --- 検索関連処理（アクティブタブに対して行う） ---
-   const handleSearch = useCallback(() => {
+  // --- 検索関連処理 ---
+  const handleSearch = useCallback(() => {
     if (!activeTabData) return;
     const results = searchJson(activeTabData.jsonData, activeTabData.searchQuery);
     updateTabData(activeTabData.id, { searchResults: results, currentResultIndex: results.length > 0 ? 0 : -1 });
@@ -242,26 +436,22 @@ function App() {
 
   const clearSearch = useCallback(() => {
     if (!activeTabData) return;
-    // 検索クエリ、結果、インデックスをリセット
     updateTabData(activeTabData.id, { searchQuery: '', searchResults: [], currentResultIndex: -1 });
   }, [activeTabData, updateTabData]);
 
-   const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-     if (!activeTabData) return;
-     const query = e.target.value;
-     // 検索クエリのみ更新し、結果はEnterかボタンで実行
-     updateTabData(activeTabData.id, { searchQuery: query, searchResults: [], currentResultIndex: -1 }); // 入力変更で結果はクリア
-   }, [activeTabData, updateTabData]);
+  const handleSearchInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!activeTabData) return;
+    const query = e.target.value;
+    updateTabData(activeTabData.id, { searchQuery: query, searchResults: [], currentResultIndex: -1 });
+  }, [activeTabData, updateTabData]);
 
   const handleSearchKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.nativeEvent.isComposing || e.key !== 'Enter') return;
-    if (!activeTabData || !activeTabData.searchQuery) return; // クエリがない場合は何もしない
-
-    // Enterキーで検索実行または次の結果へ
+    if (!activeTabData || !activeTabData.searchQuery) return;
     if (activeTabData.searchResults.length > 0) {
-        handleNextResult(); // 既に結果がある場合は次へ
+      handleNextResult();
     } else {
-        handleSearch(); // 結果がない場合は検索実行
+      handleSearch();
     }
   }, [activeTabData, handleSearch, handleNextResult]);
 
@@ -272,27 +462,37 @@ function App() {
         tabs={tabs}
         activeTabId={activeTabId}
         onSelectTab={setActiveTabId}
-        onCloseTab={closeTab}
-        onAddTab={() => addTab(null, null, true)} // 「+」ボタンで空タブ追加
+        onCloseTab={closeTabWithCheck}
+        onAddTab={() => addTab(null, null, true)}
       />
-      <div className="json-view-area"> {/* タブ下のコンテンツエリア */}
+      <div className="json-view-area">
         {activeTabData ? (
           <JsonViewComponent
-            key={activeTabData.id} // タブ切り替え時にコンポーネントを再生成して状態をリセット
+            key={activeTabData.id}
             tabData={activeTabData}
-            // onDataChange={(updates) => updateTabData(activeTabData.id, updates)} // JsonViewComponent が直接状態を変える必要はない
             onSearchInputChange={handleSearchInputChange}
             onSearchKeyDown={handleSearchKeyDown}
             onSearchExecute={handleSearch}
             onNextResult={handleNextResult}
             onClearSearch={clearSearch}
+            onDataChange={handleDataChange}
+            onDelete={handleDelete}
+            onAddProperty={handleAddProperty}
+            onAddArrayItem={handleAddArrayItem}
+            onRenameKey={handleRenameKey}
+            onToggleEditMode={toggleEditMode}
+            onToggleViewMode={toggleViewMode}
+            onSave={() => handleSave()}
+            onUndo={handleUndo}
+            onRedo={handleRedo}
+            onTextEditorChange={handleTextEditorChange}
           />
         ) : (
           <div className="center-panel">
             {tabs.length > 0 ? (
-                <p>タブを選択してください。</p>
+              <p>タブを選択してください。</p>
             ) : (
-                <p>ファイルを開くか、ドラッグ＆ドロップ、または「+」ボタンで新しいタブを開始してください。</p>
+              <p>ファイルを開くか、ドラッグ＆ドロップ、または「+」ボタンで新しいタブを開始してください。</p>
             )}
           </div>
         )}
@@ -303,17 +503,13 @@ function App() {
 
 function searchJson(json: any, query: string) {
   const results: { path: string; value: any; }[] = [];
-  const searchQuery = query.toLowerCase(); // クエリを小文字に変換
+  const searchQuery = query.toLowerCase();
   const search = (obj: any, path = '') => {
     if (typeof obj === 'object' && obj !== null) {
-      // Note: A more robust solution might handle circular references.
-      // Limit recursion depth to prevent stack overflow with large/deep objects
-      const currentDepth = path.split('.').length + path.split('[').length -1;
-      if (currentDepth > 50) { // Adjust depth limit as needed
-        // console.warn(`Search depth limit reached at path: ${path}`);
+      const currentDepth = path.split('.').length + path.split('[').length - 1;
+      if (currentDepth > 50) {
         return;
       }
-
       for (const key in obj) {
         if (obj.hasOwnProperty(key)) {
           const value = obj[key];

--- a/src/renderer/src/components/Cell/ArrayRow.tsx
+++ b/src/renderer/src/components/Cell/ArrayRow.tsx
@@ -15,9 +15,12 @@ interface ArrayRowProps {
   currentResultIndex?: number;
   searchInputRef?: any;
   path: string;
+  isEditMode?: boolean;
+  onDataChange?: (path: string, newValue: any) => void;
+  onDelete?: (path: string) => void;
 }
 
-const ArrayRow: React.FC<ArrayRowProps> = ({ element, index, columns = [], depth, searchQuery, searchResults, currentResultIndex, searchInputRef, path }) => {
+const ArrayRow: React.FC<ArrayRowProps> = ({ element, index, columns = [], depth, searchQuery, searchResults, currentResultIndex, searchInputRef, path, isEditMode = false, onDataChange, onDelete }) => {
   const typeOfEl = Array.isArray(element) ? 'array' :
     element === null ? 'null' :
     typeof element;
@@ -36,6 +39,9 @@ const ArrayRow: React.FC<ArrayRowProps> = ({ element, index, columns = [], depth
               currentResultIndex={currentResultIndex}
               searchInputRef={searchInputRef}
               path={`${path}.${header}`}
+              isEditMode={isEditMode}
+              onDataChange={onDataChange}
+              onDelete={onDelete}
             />
           </td>
         ))
@@ -49,7 +55,19 @@ const ArrayRow: React.FC<ArrayRowProps> = ({ element, index, columns = [], depth
             currentResultIndex={currentResultIndex}
             searchInputRef={searchInputRef}
             path={path}
+            isEditMode={isEditMode}
+            onDataChange={onDataChange}
+            onDelete={onDelete}
           />
+        </td>
+      )}
+      {isEditMode && (
+        <td className="row-actions">
+          <button
+            className="delete-row-btn"
+            onClick={(e) => { e.stopPropagation(); onDelete?.(path); }}
+            title="削除"
+          >✕</button>
         </td>
       )}
     </tr>

--- a/src/renderer/src/components/Cell/ArrayTable.tsx
+++ b/src/renderer/src/components/Cell/ArrayTable.tsx
@@ -10,12 +10,16 @@ interface Props {
   currentResultIndex?: number;
   searchInputRef?: any;
   path: string;
+  isEditMode?: boolean;
+  onDataChange?: (path: string, newValue: any) => void;
+  onDelete?: (path: string) => void;
+  onAddItem?: (path: string, value: any) => void;
 }
 
-const ArrayTable: React.FC<Props> = ({ array, depth, searchQuery, searchResults, currentResultIndex, searchInputRef, path }) => {
+const ArrayTable: React.FC<Props> = ({ array, depth, searchQuery, searchResults, currentResultIndex, searchInputRef, path, isEditMode = false, onDataChange, onDelete, onAddItem }) => {
   const headers = React.useMemo(() => {
     const hdrCells = array.reduce<Array<string>>((hdrs, el) => {
-      if (typeof el === 'object') {
+      if (typeof el === 'object' && el !== null) {
         return [...new Set([...hdrs, ...Object.keys(el)])];
       }
       return hdrs;
@@ -25,8 +29,12 @@ const ArrayTable: React.FC<Props> = ({ array, depth, searchQuery, searchResults,
       thClass: "array member"
     }));
 
-    return [{ header: '', resize: false, thClass: 'index' }, ...hdrCells];
-  }, [array]);
+    const base = [{ header: '', resize: false, thClass: 'index' }, ...hdrCells];
+    if (isEditMode) {
+      return [...base, { header: '', resize: false, thClass: 'edit-actions' }];
+    }
+    return base;
+  }, [array, isEditMode]);
 
   const highlightText = (text: string, query: string) => {
     if (!query) return text;
@@ -53,7 +61,7 @@ const ArrayTable: React.FC<Props> = ({ array, depth, searchQuery, searchResults,
     >
       {array.map((item, index) => (
         <ArrayRow
-          key={index}
+          key={`${index}-${array.length}`}
           element={item}
           index={index}
           columns={headers}
@@ -63,8 +71,21 @@ const ArrayTable: React.FC<Props> = ({ array, depth, searchQuery, searchResults,
           currentResultIndex={currentResultIndex}
           searchInputRef={searchInputRef}
           path={`${path}[${index}]`}
+          isEditMode={isEditMode}
+          onDataChange={onDataChange}
+          onDelete={onDelete}
         />
       ))}
+      {isEditMode && (
+        <tr className="array-el add-row">
+          <td className="index add-cell" colSpan={headers.length}>
+            <button
+              className="add-row-btn"
+              onClick={() => onAddItem?.(path, null)}
+            >+ 要素を追加</button>
+          </td>
+        </tr>
+      )}
     </ResizableTable>
   );
 };

--- a/src/renderer/src/components/Cell/Cell.tsx
+++ b/src/renderer/src/components/Cell/Cell.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useLayoutEffect, memo, useRef, useEffect, useCallback } from 'react';
 import ArrayTable from './ArrayTable';
 import ObjectTable from './ObjectTable';
+import EditableCell from './EditableCell';
 
 interface CellProps {
   element: any;
@@ -11,18 +12,19 @@ interface CellProps {
   searchInputRef?: any;
   path?: string;
   isRoot?: boolean;
+  isEditMode?: boolean;
+  onDataChange?: (path: string, newValue: any) => void;
+  onDelete?: (path: string) => void;
 }
 
-const Cell: React.FC<CellProps> = ({ element, depth = 0, searchQuery, searchResults, currentResultIndex, searchInputRef, path = '', isRoot = false }) => {
-  // isRoot または検索結果に含まれる/始まる場合はデフォルトで展開
+const Cell: React.FC<CellProps> = ({ element, depth = 0, searchQuery, searchResults, currentResultIndex, searchInputRef, path = '', isRoot = false, isEditMode = false, onDataChange, onDelete }) => {
   const isInitiallyExpanded = isRoot || searchResults?.some(result => result.path.startsWith(path));
   const [expanded, setExpanded] = useState(isInitiallyExpanded);
-  const cellRef = useRef<HTMLDivElement>(null); // 型を指定
+  const cellRef = useRef<HTMLDivElement>(null);
 
-  // searchQuery が変更されたら isInitiallyExpanded に基づいて展開状態をリセット
   useEffect(() => {
     setExpanded(isRoot || searchResults?.some(result => result.path.startsWith(path)) || false);
-  }, [searchQuery, searchResults, path, isRoot]); // searchQuery と searchResults を依存関係に追加
+  }, [searchQuery, searchResults, path, isRoot]);
 
   const toggleExpanded = useCallback(() => {
     setExpanded(!expanded);
@@ -37,15 +39,13 @@ const Cell: React.FC<CellProps> = ({ element, depth = 0, searchQuery, searchResu
   }, []);
 
   useEffect(() => {
-    // 検索結果が更新され、このCellが親である場合に展開する
     const shouldExpand = searchResults?.some(result => result.path !== path && result.path.startsWith(path));
     if (shouldExpand && !expanded) {
       setExpanded(true);
     }
-  }, [searchResults, currentResultIndex, path, expanded]); // expanded を依存関係に追加
+  }, [searchResults, currentResultIndex, path, expanded]);
 
   useLayoutEffect(() => {
-    // このCell自体が現在の検索結果である場合にスクロールして表示（親コンポーネントで管理されるべき）
     if (searchResults && currentResultIndex !== undefined && searchResults[currentResultIndex]?.path === path && cellRef.current) {
       cellRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
       setExpanded(true);
@@ -77,7 +77,7 @@ const Cell: React.FC<CellProps> = ({ element, depth = 0, searchQuery, searchResu
           onKeyDown={handleKeyDown}
         >{expanded ? '-' : '+'}
         </span>
-        {expanded && <ArrayTable array={element} depth={depth + 1} searchQuery={searchQuery} searchResults={searchResults} currentResultIndex={currentResultIndex} searchInputRef={searchInputRef} path={path} />}
+        {expanded && <ArrayTable array={element} depth={depth + 1} searchQuery={searchQuery} searchResults={searchResults} currentResultIndex={currentResultIndex} searchInputRef={searchInputRef} path={path} isEditMode={isEditMode} onDataChange={onDataChange} onDelete={onDelete} />}
       </div>
     );
   } else if (typeof element === 'object' && element !== null) {
@@ -89,11 +89,19 @@ const Cell: React.FC<CellProps> = ({ element, depth = 0, searchQuery, searchResu
           onKeyDown={handleKeyDown}
         >{expanded ? '-' : '+'}</span>
         {expanded &&
-          <ObjectTable member={element} depth={depth + 1} searchQuery={searchQuery} searchResults={searchResults} currentResultIndex={currentResultIndex} searchInputRef={searchInputRef} path={path} />}
+          <ObjectTable member={element} depth={depth + 1} searchQuery={searchQuery} searchResults={searchResults} currentResultIndex={currentResultIndex} searchInputRef={searchInputRef} path={path} isEditMode={isEditMode} onDataChange={onDataChange} onDelete={onDelete} />}
       </div>
     );
   } else {
-    // この値自体が現在の検索結果か？
+    if (isEditMode && onDataChange) {
+      return (
+        <EditableCell
+          value={element}
+          path={path}
+          onCommit={onDataChange}
+        />
+      );
+    }
     const isCurrentValueResult = searchResults && currentResultIndex !== undefined && searchResults[currentResultIndex]?.path === path;
     const valueString = String(element);
     return (

--- a/src/renderer/src/components/Cell/CellUtils.ts
+++ b/src/renderer/src/components/Cell/CellUtils.ts
@@ -1,0 +1,175 @@
+export function parsePath(path: string): (string | number)[] {
+  if (!path) return []
+  const segments: (string | number)[] = []
+  const regex = /\.([^\.\[]+)|\[(\d+)\]/g
+  let match
+  while ((match = regex.exec(path)) !== null) {
+    if (match[1] !== undefined) {
+      segments.push(match[1])
+    } else if (match[2] !== undefined) {
+      segments.push(parseInt(match[2], 10))
+    }
+  }
+  return segments
+}
+
+export function getValueByPath(root: any, path: string): any {
+  const segments = parsePath(path)
+  let current = root
+  for (const seg of segments) {
+    if (current == null || typeof current !== 'object') return undefined
+    current = current[seg]
+  }
+  return current
+}
+
+export function setValueByPath(root: any, path: string, newValue: any): any {
+  if (!path) return newValue
+  const segments = parsePath(path)
+  return setValueRecursive(root, segments, 0, newValue)
+}
+
+function setValueRecursive(obj: any, segments: (string | number)[], index: number, newValue: any): any {
+  if (index === segments.length) return newValue
+  const seg = segments[index]
+  if (Array.isArray(obj)) {
+    const arr = [...obj]
+    arr[seg as number] = setValueRecursive(obj[seg as number], segments, index + 1, newValue)
+    return arr
+  }
+  if (obj != null && typeof obj === 'object') {
+    return { ...obj, [seg]: setValueRecursive(obj[seg], segments, index + 1, newValue) }
+  }
+  return obj
+}
+
+export function deleteByPath(root: any, path: string): any {
+  if (!path) return root
+  const segments = parsePath(path)
+  if (segments.length === 0) return root
+  return deleteRecursive(root, segments, 0)
+}
+
+function deleteRecursive(obj: any, segments: (string | number)[], index: number): any {
+  const seg = segments[index]
+  const isLast = index === segments.length - 1
+  if (isLast) {
+    if (Array.isArray(obj)) {
+      const arr = [...obj]
+      arr.splice(seg as number, 1)
+      return arr
+    }
+    if (obj != null && typeof obj === 'object') {
+      const { [seg]: _, ...rest } = obj
+      return rest
+    }
+    return obj
+  }
+  if (Array.isArray(obj)) {
+    const arr = [...obj]
+    arr[seg as number] = deleteRecursive(obj[seg as number], segments, index + 1)
+    return arr
+  }
+  if (obj != null && typeof obj === 'object') {
+    return { ...obj, [seg]: deleteRecursive(obj[seg], segments, index + 1) }
+  }
+  return obj
+}
+
+export function addPropertyByPath(root: any, path: string, key: string, value: any): any {
+  const target = path ? getValueByPath(root, path) : root
+  if (target == null || typeof target !== 'object') return root
+  if (Array.isArray(target)) {
+    const newArr = [...target, value]
+    return path ? setValueByPath(root, path, newArr) : newArr
+  }
+  const newObj = { ...target, [key]: value }
+  return path ? setValueByPath(root, path, newObj) : newObj
+}
+
+export function addArrayItemByPath(root: any, path: string, value: any, index?: number): any {
+  const target = path ? getValueByPath(root, path) : root
+  if (!Array.isArray(target)) return root
+  const newArr = [...target]
+  if (index !== undefined && index >= 0 && index <= newArr.length) {
+    newArr.splice(index, 0, value)
+  } else {
+    newArr.push(value)
+  }
+  return path ? setValueByPath(root, path, newArr) : newArr
+}
+
+export function renameKeyByPath(root: any, parentPath: string, oldKey: string, newKey: string): any {
+  const target = parentPath ? getValueByPath(root, parentPath) : root
+  if (target == null || typeof target !== 'object' || Array.isArray(target)) return root
+  if (!(oldKey in target)) return root
+  const entries = Object.entries(target)
+  const newEntries = entries.map(([k, v]) => (k === oldKey ? [newKey, v] : [k, v]))
+  const newObj = Object.fromEntries(newEntries)
+  return parentPath ? setValueByPath(root, parentPath, newObj) : newObj
+}
+
+export function applyOperation(root: any, op: import('../../App').DataOperation): any {
+  switch (op.type) {
+    case 'set':
+      return setValueByPath(root, op.path, op.value)
+    case 'delete':
+      return deleteByPath(root, op.path)
+    case 'add': {
+      const parent = op.path ? getValueByPath(root, op.path) : root
+      if (Array.isArray(parent)) {
+        return addArrayItemByPath(root, op.path, op.value)
+      }
+      return addPropertyByPath(root, op.path, op.key || 'newKey', op.value)
+    }
+    case 'rename': {
+      const segments = parsePath(op.path)
+      const parentPath = segments.slice(0, -1).reduce((acc, seg) => {
+        if (typeof seg === 'number') return `${acc}[${seg}]`
+        return `${acc}.${seg}`
+      }, '')
+      return renameKeyByPath(root, parentPath, op.key || '', op.newKey || '')
+    }
+    default:
+      return root
+  }
+}
+
+export function invertOperation(root: any, op: import('../../App').DataOperation): import('../../App').DataOperation {
+  switch (op.type) {
+    case 'set': {
+      const oldValue = getValueByPath(root, op.path)
+      return { type: 'set', path: op.path, value: oldValue }
+    }
+    case 'delete': {
+      const oldValue = getValueByPath(root, op.path)
+      return { type: 'set', path: op.path, value: oldValue }
+    }
+    case 'add': {
+      const parent = op.path ? getValueByPath(root, op.path) : root
+      if (Array.isArray(parent)) {
+        const idx = parent.length
+        return { type: 'delete', path: `${op.path}[${idx}]` }
+      }
+      return { type: 'delete', path: `${op.path ? op.path : ''}.${op.key}` }
+    }
+    case 'rename':
+      return { type: 'rename', path: op.path, key: op.newKey, newKey: op.key }
+    default:
+      return op
+  }
+}
+
+export function coerceValue(rawValue: string, originalType: string): any {
+  if (rawValue === 'null') return null
+  if (rawValue === 'true') return true
+  if (rawValue === 'false') return false
+  if (originalType === 'number') {
+    const num = Number(rawValue)
+    return isNaN(num) ? rawValue : num
+  }
+  if (originalType === 'boolean') {
+    return rawValue === 'true'
+  }
+  return rawValue
+}

--- a/src/renderer/src/components/Cell/EditableCell.tsx
+++ b/src/renderer/src/components/Cell/EditableCell.tsx
@@ -1,0 +1,127 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { coerceValue } from './CellUtils'
+
+interface EditableCellProps {
+  value: any
+  path: string
+  onCommit: (path: string, newValue: any) => void
+}
+
+const EditableCell: React.FC<EditableCellProps> = ({ value, path, onCommit }) => {
+  const [editing, setEditing] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [editing])
+
+  const startEditing = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
+    if (e.type === 'keydown') {
+      const ke = e as React.KeyboardEvent
+      if (ke.key !== 'Enter' && ke.key !== 'F2') return
+      if (ke.nativeEvent.isComposing) return
+    }
+    e.stopPropagation()
+    setEditing(true)
+    if (value === null) {
+      setInputValue('null')
+    } else if (typeof value === 'boolean') {
+      setInputValue(String(value))
+    } else {
+      setInputValue(String(value))
+    }
+  }, [value])
+
+  const commit = useCallback(() => {
+    const originalType = value === null ? 'null' : typeof value
+    const newValue = coerceValue(inputValue, originalType)
+    if (newValue !== value) {
+      onCommit(path, newValue)
+    }
+    setEditing(false)
+  }, [inputValue, value, path, onCommit])
+
+  const cancel = useCallback(() => {
+    setEditing(false)
+  }, [])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.nativeEvent.isComposing) return
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      commit()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancel()
+    }
+  }, [commit, cancel])
+
+  const handleBlur = useCallback(() => {
+    commit()
+  }, [commit])
+
+  if (typeof value === 'boolean') {
+    return (
+      <span
+        className={`value boolean editable-cell editable-boolean`}
+        data-path={path}
+        onClick={(e) => {
+          e.stopPropagation()
+          onCommit(path, !value)
+        }}
+        title="クリックで切替"
+      >
+        {String(value)}
+      </span>
+    )
+  }
+
+  if (value === null) {
+    if (!editing) {
+      return (
+        <span
+          className={`value null editable-cell`}
+          data-path={path}
+          onDoubleClick={startEditing}
+          onKeyDown={startEditing}
+          tabIndex={0}
+          title="ダブルクリックで編集"
+        />
+      )
+    }
+  }
+
+  if (!editing) {
+    return (
+      <span
+        className={`value ${typeof value} editable-cell`}
+        data-path={path}
+        onDoubleClick={startEditing}
+        onKeyDown={startEditing}
+        tabIndex={0}
+        title="ダブルクリックで編集"
+      >
+        {String(value)}
+      </span>
+    )
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      className="editable-input"
+      type="text"
+      value={inputValue}
+      onChange={(e) => setInputValue(e.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={handleBlur}
+      onClick={(e) => e.stopPropagation()}
+    />
+  )
+}
+
+export default React.memo(EditableCell)

--- a/src/renderer/src/components/Cell/EditableCell.tsx
+++ b/src/renderer/src/components/Cell/EditableCell.tsx
@@ -7,17 +7,33 @@ interface EditableCellProps {
   onCommit: (path: string, newValue: any) => void
 }
 
+const LINE_HEIGHT = 20
+
+const needsTextarea = (v: any, measuredHeight: number | undefined) => {
+  if (typeof v === 'string' && v.includes('\n')) return true
+  if (measuredHeight !== undefined && measuredHeight > LINE_HEIGHT * 1.2) return true
+  return false
+}
+
 const EditableCell: React.FC<EditableCellProps> = ({ value, path, onCommit }) => {
   const [editing, setEditing] = useState(false)
   const [inputValue, setInputValue] = useState('')
+  const [measuredSize, setMeasuredSize] = useState<{ width: number; height: number } | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const measureRef = useRef<HTMLSpanElement>(null)
+  const useTextarea = needsTextarea(value, measuredSize?.height)
 
   useEffect(() => {
-    if (editing && inputRef.current) {
+    if (!editing) return
+    if (useTextarea && textareaRef.current) {
+      textareaRef.current.focus()
+      textareaRef.current.select()
+    } else if (inputRef.current) {
       inputRef.current.focus()
       inputRef.current.select()
     }
-  }, [editing])
+  }, [editing, useTextarea])
 
   const startEditing = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
     if (e.type === 'keydown') {
@@ -26,6 +42,12 @@ const EditableCell: React.FC<EditableCellProps> = ({ value, path, onCommit }) =>
       if (ke.nativeEvent.isComposing) return
     }
     e.stopPropagation()
+
+    if (measureRef.current) {
+      const rect = measureRef.current.getBoundingClientRect()
+      setMeasuredSize({ width: rect.width, height: rect.height })
+    }
+
     setEditing(true)
     if (value === null) {
       setInputValue('null')
@@ -43,22 +65,27 @@ const EditableCell: React.FC<EditableCellProps> = ({ value, path, onCommit }) =>
       onCommit(path, newValue)
     }
     setEditing(false)
+    setMeasuredSize(null)
   }, [inputValue, value, path, onCommit])
 
   const cancel = useCallback(() => {
     setEditing(false)
+    setMeasuredSize(null)
   }, [])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.nativeEvent.isComposing) return
-    if (e.key === 'Enter') {
+    if (useTextarea && e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      e.preventDefault()
+      commit()
+    } else if (!useTextarea && e.key === 'Enter') {
       e.preventDefault()
       commit()
     } else if (e.key === 'Escape') {
       e.preventDefault()
       cancel()
     }
-  }, [commit, cancel])
+  }, [commit, cancel, useTextarea])
 
   const handleBlur = useCallback(() => {
     commit()
@@ -98,6 +125,7 @@ const EditableCell: React.FC<EditableCellProps> = ({ value, path, onCommit }) =>
   if (!editing) {
     return (
       <span
+        ref={measureRef}
         className={`value ${typeof value} editable-cell`}
         data-path={path}
         onDoubleClick={startEditing}
@@ -107,6 +135,25 @@ const EditableCell: React.FC<EditableCellProps> = ({ value, path, onCommit }) =>
       >
         {String(value)}
       </span>
+    )
+  }
+
+  if (useTextarea) {
+    const style: React.CSSProperties = measuredSize
+      ? { width: measuredSize.width, minHeight: measuredSize.height }
+      : undefined
+    return (
+      <textarea
+        ref={textareaRef}
+        className="editable-textarea"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        onClick={(e) => e.stopPropagation()}
+        rows={Math.min(inputValue.split('\n').length, 10)}
+        style={style}
+      />
     )
   }
 

--- a/src/renderer/src/components/Cell/FileUtils.ts
+++ b/src/renderer/src/components/Cell/FileUtils.ts
@@ -2,9 +2,28 @@ import yaml from 'js-yaml'
 
 export type FileType = 'json' | 'yaml'
 
-function preprocessYaml(text: string): string {
-  return text.replace(/(?<![!"'])![a-zA-Z][a-zA-Z0-9_:/-]*/g, '')
-}
+const tolerantSchema = yaml.DEFAULT_SCHEMA.extend({
+  explicit: [
+    new yaml.Type('!', {
+      kind: 'scalar',
+      multi: true,
+      resolve: () => true,
+      construct: (data) => data ?? '',
+    }),
+    new yaml.Type('!', {
+      kind: 'mapping',
+      multi: true,
+      resolve: () => true,
+      construct: (data) => data ?? {},
+    }),
+    new yaml.Type('!', {
+      kind: 'sequence',
+      multi: true,
+      resolve: () => true,
+      construct: (data) => data ?? [],
+    }),
+  ],
+})
 
 export function detectFileType(filePath: string | null): FileType {
   if (!filePath) return 'json'
@@ -14,17 +33,17 @@ export function detectFileType(filePath: string | null): FileType {
 }
 
 export function parseContent(rawText: string, fileType: FileType): any {
-  if (fileType === 'yaml') return yaml.load(preprocessYaml(rawText))
+  if (fileType === 'yaml') return yaml.load(rawText, { schema: tolerantSchema })
   return JSON.parse(rawText)
 }
 
 export function serializeData(data: any, fileType: FileType): string {
-  if (fileType === 'yaml') return yaml.dump(data, { indent: 2, lineWidth: -1 })
+  if (fileType === 'yaml') return yaml.dump(data, { indent: 2, lineWidth: -1, schema: tolerantSchema })
   return JSON.stringify(data, null, 2)
 }
 
 export function validateText(text: string, fileType: FileType): any {
-  if (fileType === 'yaml') return yaml.load(preprocessYaml(text))
+  if (fileType === 'yaml') return yaml.load(text, { schema: tolerantSchema })
   return JSON.parse(text)
 }
 

--- a/src/renderer/src/components/Cell/FileUtils.ts
+++ b/src/renderer/src/components/Cell/FileUtils.ts
@@ -1,0 +1,33 @@
+import yaml from 'js-yaml'
+
+export type FileType = 'json' | 'yaml'
+
+function preprocessYaml(text: string): string {
+  return text.replace(/(?<![!"'])![a-zA-Z][a-zA-Z0-9_:/-]*/g, '')
+}
+
+export function detectFileType(filePath: string | null): FileType {
+  if (!filePath) return 'json'
+  const ext = filePath.split('.').pop()?.toLowerCase()
+  if (ext === 'yaml' || ext === 'yml') return 'yaml'
+  return 'json'
+}
+
+export function parseContent(rawText: string, fileType: FileType): any {
+  if (fileType === 'yaml') return yaml.load(preprocessYaml(rawText))
+  return JSON.parse(rawText)
+}
+
+export function serializeData(data: any, fileType: FileType): string {
+  if (fileType === 'yaml') return yaml.dump(data, { indent: 2, lineWidth: -1 })
+  return JSON.stringify(data, null, 2)
+}
+
+export function validateText(text: string, fileType: FileType): any {
+  if (fileType === 'yaml') return yaml.load(preprocessYaml(text))
+  return JSON.parse(text)
+}
+
+export function defaultFileName(fileType: FileType): string {
+  return fileType === 'yaml' ? 'untitled.yaml' : 'untitled.json'
+}

--- a/src/renderer/src/components/Cell/ObjectTable.tsx
+++ b/src/renderer/src/components/Cell/ObjectTable.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useMemo, useState, useCallback } from 'react';
 import ResizableTable from './ResizableTable';
 import Cell from './Cell';
 
@@ -10,6 +10,11 @@ interface ObjectTableProps {
   currentResultIndex?: number;
   searchInputRef?: any;
   path: string;
+  isEditMode?: boolean;
+  onDataChange?: (path: string, newValue: any) => void;
+  onDelete?: (path: string) => void;
+  onAddProperty?: (path: string, key: string, value: any) => void;
+  onRenameKey?: (path: string, oldKey: string, newKey: string) => void;
 }
 
 interface Header {
@@ -17,11 +22,17 @@ interface Header {
   thClass: string;
 }
 
-const ObjectTable: React.FC<ObjectTableProps> = ({ member, depth, searchQuery, searchResults, currentResultIndex, searchInputRef, path }) => {
-  const headers: Header[] = useMemo(() => [
-    { header: 'key', thClass: 'object key' },
-    { header: 'val', thClass: 'object value' }
-  ], []);
+const ObjectTable: React.FC<ObjectTableProps> = ({ member, depth, searchQuery, searchResults, currentResultIndex, searchInputRef, path, isEditMode = false, onDataChange, onDelete, onAddProperty, onRenameKey }) => {
+  const headers: Header[] = useMemo(() => {
+    const base = [
+      { header: 'key', thClass: 'object key' },
+      { header: 'val', thClass: 'object value' }
+    ];
+    if (isEditMode) {
+      return [...base, { header: '', thClass: 'edit-actions' }];
+    }
+    return base;
+  }, [isEditMode]);
 
   const highlightText = (text: string, query: string) => {
     if (!query) return text;
@@ -34,6 +45,31 @@ const ObjectTable: React.FC<ObjectTableProps> = ({ member, depth, searchQuery, s
       )
     );
   };
+
+  const [newKeyName, setNewKeyName] = useState('');
+  const [addingNew, setAddingNew] = useState(false);
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editingKeyValue, setEditingKeyValue] = useState('');
+
+  const handleAddProperty = useCallback(() => {
+    if (!newKeyName.trim()) return;
+    onAddProperty?.(path, newKeyName.trim(), '');
+    setNewKeyName('');
+    setAddingNew(false);
+  }, [newKeyName, path, onAddProperty]);
+
+  const handleStartRename = useCallback((key: string) => {
+    setEditingKey(key);
+    setEditingKeyValue(key);
+  }, []);
+
+  const handleCommitRename = useCallback((oldKey: string) => {
+    if (editingKeyValue.trim() && editingKeyValue !== oldKey) {
+      onRenameKey?.(path, oldKey, editingKeyValue.trim());
+    }
+    setEditingKey(null);
+    setEditingKeyValue('');
+  }, [editingKeyValue, path, onRenameKey]);
 
   return (
     <ResizableTable
@@ -48,8 +84,26 @@ const ObjectTable: React.FC<ObjectTableProps> = ({ member, depth, searchQuery, s
                 searchResults?.some((r, idx) => idx === currentResultIndex && r.path === `${path}.${key}` && r.value === key)
                 ? 'current-highlight'
                 : ''
-             }`}>
-            {highlightText(key, searchQuery || '')}
+              }`}
+              onDoubleClick={() => isEditMode && handleStartRename(key)}
+          >
+            {editingKey === key ? (
+              <input
+                className="key-edit-input"
+                value={editingKeyValue}
+                onChange={(e) => setEditingKeyValue(e.target.value)}
+                onBlur={() => handleCommitRename(key)}
+                onKeyDown={(e) => {
+                  if (e.nativeEvent.isComposing) return
+                  if (e.key === 'Enter') handleCommitRename(key)
+                  if (e.key === 'Escape') setEditingKey(null)
+                }}
+                autoFocus
+                onClick={(e) => e.stopPropagation()}
+              />
+            ) : (
+              isEditMode ? highlightText(key, searchQuery || '') : highlightText(key, searchQuery || '')
+            )}
           </th>
           <td className="object element">
             <Cell
@@ -60,10 +114,49 @@ const ObjectTable: React.FC<ObjectTableProps> = ({ member, depth, searchQuery, s
               currentResultIndex={currentResultIndex}
               searchInputRef={searchInputRef}
               path={`${path}.${key}`}
+              isEditMode={isEditMode}
+              onDataChange={onDataChange}
+              onDelete={onDelete}
             />
           </td>
+          {isEditMode && (
+            <td className="row-actions">
+              <button
+                className="delete-row-btn"
+                onClick={(e) => { e.stopPropagation(); onDelete?.(`${path}.${key}`); }}
+                title="削除"
+              >✕</button>
+            </td>
+          )}
         </tr>
       ))}
+      {isEditMode && (
+        <tr className="object member add-row">
+          <td className="object element add-cell" colSpan={isEditMode ? 3 : 2}>
+            {addingNew ? (
+              <div className="add-property-form">
+                <input
+                  className="add-key-input"
+                  type="text"
+                  value={newKeyName}
+                  onChange={(e) => setNewKeyName(e.target.value)}
+                  placeholder="新しいキー名"
+                  onKeyDown={(e) => {
+                    if (e.nativeEvent.isComposing) return
+                    if (e.key === 'Enter') handleAddProperty()
+                    if (e.key === 'Escape') setAddingNew(false)
+                  }}
+                  autoFocus
+                />
+                <button className="add-confirm-btn" onClick={handleAddProperty}>追加</button>
+                <button className="add-cancel-btn" onClick={() => setAddingNew(false)}>取消</button>
+              </div>
+            ) : (
+              <button className="add-row-btn" onClick={() => setAddingNew(true)}>+ プロパティを追加</button>
+            )}
+          </td>
+        </tr>
+      )}
     </ResizableTable>
   );
 };

--- a/src/renderer/src/components/JsonView/JsonViewComponent.tsx
+++ b/src/renderer/src/components/JsonView/JsonViewComponent.tsx
@@ -178,7 +178,7 @@ const JsonViewComponent: React.FC<JsonViewProps> = ({
             )
           ) : (
             <div className="center-panel">
-              <p>JSONファイルをドラッグ&ドロップしてください</p>
+              <p>JSON/YAMLファイルをドラッグ&ドロップしてください</p>
             </div>
           )
         ) : (
@@ -209,7 +209,7 @@ const JsonViewComponent: React.FC<JsonViewProps> = ({
             </div>
           ) : (
             <div className="center-panel">
-              <p>JSONファイルをドラッグ&ドロップしてください</p>
+              <p>JSON/YAMLファイルをドラッグ&ドロップしてください</p>
             </div>
           )
         )}

--- a/src/renderer/src/components/JsonView/JsonViewComponent.tsx
+++ b/src/renderer/src/components/JsonView/JsonViewComponent.tsx
@@ -1,18 +1,27 @@
-// src/renderer/src/components/JsonView/JsonViewComponent.tsx
-// 新規作成
 import React, { useRef, useEffect, useCallback } from 'react';
-import Cell from '../Cell/Cell'; // Cellコンポーネントをインポート
-import { TabState } from '../../App'; // App.tsx から TabState をインポート
-import '../../App.css'; // App.css または専用のCSS
+import Cell from '../Cell/Cell';
+import TextEditor from './TextEditor';
+import { TabState } from '../../App';
+import '../../App.css';
 
 interface JsonViewProps {
   tabData: TabState;
-  // onDataChange: (updates: Partial<Omit<TabState, 'id'>>) => void; // 状態更新用コールバックはApp側で行うので削除
   onSearchInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSearchKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onSearchExecute: () => void;
   onNextResult: () => void;
   onClearSearch: () => void;
+  onDataChange?: (path: string, newValue: any) => void;
+  onDelete?: (path: string) => void;
+  onAddProperty?: (path: string, key: string, value: any) => void;
+  onAddArrayItem?: (path: string, value: any) => void;
+  onRenameKey?: (path: string, oldKey: string, newKey: string) => void;
+  onToggleEditMode?: () => void;
+  onToggleViewMode?: () => void;
+  onSave?: () => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+  onTextEditorChange?: (newText: string) => void;
 }
 
 const JsonViewComponent: React.FC<JsonViewProps> = ({
@@ -22,149 +31,183 @@ const JsonViewComponent: React.FC<JsonViewProps> = ({
   onSearchExecute,
   onNextResult,
   onClearSearch,
+  onDataChange,
+  onDelete,
+  onAddProperty,
+  onAddArrayItem,
+  onRenameKey,
+  onToggleEditMode,
+  onToggleViewMode,
+  onSave,
+  onUndo,
+  onRedo,
+  onTextEditorChange,
 }) => {
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const jsonViewerContainerRef = useRef<HTMLDivElement>(null); // コンテナのref
+  const jsonViewerContainerRef = useRef<HTMLDivElement>(null);
 
-  // ハイライトとスクロールを管理する関数
   const manageHighlightAndScroll = useCallback(() => {
     const container = jsonViewerContainerRef.current;
     if (!container) return;
 
-    // 既存のハイライトをすべてクリア
     container.querySelectorAll('.highlight, .current-highlight').forEach(el => {
-        el.classList.remove('highlight', 'current-highlight');
+      el.classList.remove('highlight', 'current-highlight');
     });
 
     if (tabData.searchResults.length > 0 && tabData.currentResultIndex >= 0) {
       const currentResult = tabData.searchResults[tabData.currentResultIndex];
       if (currentResult) {
-        // 少し待ってから要素を探してスクロール
         const timeoutId = setTimeout(() => {
           try {
-            // CSSセレクター用にパスをエスケープ
             const escapedPath = CSS.escape(currentResult.path);
-            // data-path属性を持つ要素を探す (Cell または th.key)
             const element = container.querySelector(`[data-path="${escapedPath}"], th.key[data-path="${escapedPath}"]`);
-
             if (element) {
-               // 現在の結果にハイライトクラスを追加
               element.classList.add('current-highlight');
-
-              // 要素がビューポート内に表示されているか確認
               const elementRect = element.getBoundingClientRect();
               const containerRect = container.getBoundingClientRect();
-
-              // 要素がコンテナの表示領域内に完全に見えているか、または一部見えているか
-              const isVisible =
-                elementRect.top >= containerRect.top &&
-                elementRect.left >= containerRect.left &&
-                elementRect.bottom <= containerRect.bottom &&
-                elementRect.right <= containerRect.right;
-
               const isPartiallyVisible =
                 elementRect.top < containerRect.bottom &&
-                elementRect.bottom > containerRect.top; // 縦方向のみチェック（横スクロールは未考慮）
-
-              // 要素が見えていない場合のみスクロール
+                elementRect.bottom > containerRect.top;
               if (!isPartiallyVisible) {
                 element.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
               }
-            } else {
-              console.warn(`Element with data-path="${currentResult.path}" not found for highlighting/scrolling.`);
             }
           } catch (e) {
-              console.error("Error during highlight/scroll:", e);
+            console.error("Error during highlight/scroll:", e);
           }
-        }, 100); // DOM更新後のタイミングで実行するための遅延
-        return () => clearTimeout(timeoutId); // クリーンアップ
+        }, 100);
+        return () => clearTimeout(timeoutId);
       }
     }
-  }, [tabData.searchResults, tabData.currentResultIndex]); // 依存関係
+  }, [tabData.searchResults, tabData.currentResultIndex]);
 
-  // 検索結果またはインデックスが変わったらハイライトとスクロールを実行
   useEffect(() => {
     manageHighlightAndScroll();
-  }, [manageHighlightAndScroll]); // manageHighlightAndScroll 関数自体を依存関係にする
+  }, [manageHighlightAndScroll]);
 
-
-  // searchQuery が空になったらハイライトをクリア（既に manageHighlightAndScroll で処理されているかも）
   useEffect(() => {
-      if (tabData.searchQuery === '' && jsonViewerContainerRef.current) {
-           jsonViewerContainerRef.current.querySelectorAll('.highlight, .current-highlight').forEach(el => {
-             el.classList.remove('highlight', 'current-highlight');
-         });
-      }
+    if (tabData.searchQuery === '' && jsonViewerContainerRef.current) {
+      jsonViewerContainerRef.current.querySelectorAll('.highlight, .current-highlight').forEach(el => {
+        el.classList.remove('highlight', 'current-highlight');
+      });
+    }
   }, [tabData.searchQuery]);
 
+  const isEditMode = tabData.mode === 'edit';
 
   return (
-    // このコンポーネント用のラッパー div
     <div className="json-view-content">
-      {/* 検索バー */}
-      <div className="search-container">
-        <div className="search-input-wrapper">
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={tabData.searchQuery}
-            onChange={onSearchInputChange}
-            onKeyDown={onSearchKeyDown}
-            placeholder="検索 (Enterで実行/次へ)"
-            disabled={!tabData.jsonData || tabData.jsonData.error} // データがないかエラーの場合は無効化
-          />
-          {tabData.searchQuery && (
-            <button className="clear-search" onClick={onClearSearch} aria-label="Clear search"></button>
+      {/* ツールバー */}
+      <div className="edit-toolbar">
+        <div className="toolbar-left">
+          <button
+            className={`toolbar-btn mode-btn ${isEditMode ? 'active' : ''}`}
+            onClick={onToggleEditMode}
+            title={isEditMode ? '閲覧モードに切替' : '編集モードに切替'}
+          >
+            {isEditMode ? '✏️ 編集中' : '👁 閲覧中'}
+          </button>
+          <button
+            className={`toolbar-btn view-btn ${tabData.viewMode === 'text' ? 'active' : ''}`}
+            onClick={onToggleViewMode}
+            title={tabData.viewMode === 'grid' ? 'テキスト表示' : 'グリッド表示'}
+          >
+            {tabData.viewMode === 'grid' ? '{ } テキスト' : '⚏ グリッド'}
+          </button>
+          {isEditMode && (
+            <>
+              <button className="toolbar-btn" onClick={onUndo} disabled={tabData.history.undo.length === 0} title="元に戻す (Ctrl+Z)">
+                ↶ 取消
+              </button>
+              <button className="toolbar-btn" onClick={onRedo} disabled={tabData.history.redo.length === 0} title="やり直し (Ctrl+Shift+Z)">
+                ↷ 再実行
+              </button>
+              <button className="toolbar-btn save-btn" onClick={onSave} disabled={!tabData.isDirty} title="保存 (Ctrl+S)">
+                💾 保存
+              </button>
+            </>
           )}
         </div>
-        <button onClick={onSearchExecute} disabled={!tabData.searchQuery || !tabData.jsonData || tabData.jsonData.error}>
-          検索
-        </button>
-        <button
-           onMouseDown={e => e.preventDefault()} // フォーカス移動阻止
-           onClick={() => {
-             onNextResult();
-             searchInputRef.current?.focus(); // 再フォーカス
-           }}
-           disabled={tabData.searchResults.length === 0} // 結果がないときは無効化
-        >
-          次へ {tabData.searchResults.length > 0 ? `(${tabData.currentResultIndex + 1}/${tabData.searchResults.length})` : ''}
-        </button>
+        {/* 検索バー */}
+        <div className="search-container">
+          <div className="search-input-wrapper">
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={tabData.searchQuery}
+              onChange={onSearchInputChange}
+              onKeyDown={onSearchKeyDown}
+              placeholder="検索 (Enterで実行/次へ)"
+              disabled={!tabData.jsonData || tabData.jsonData.error}
+            />
+            {tabData.searchQuery && (
+              <button className="clear-search" onClick={onClearSearch} aria-label="Clear search"></button>
+            )}
+          </div>
+          <button onClick={onSearchExecute} disabled={!tabData.searchQuery || !tabData.jsonData || tabData.jsonData.error}>
+            検索
+          </button>
+          <button
+            onMouseDown={e => e.preventDefault()}
+            onClick={() => {
+              onNextResult();
+              searchInputRef.current?.focus();
+            }}
+            disabled={tabData.searchResults.length === 0}
+          >
+            次へ {tabData.searchResults.length > 0 ? `(${tabData.currentResultIndex + 1}/${tabData.searchResults.length})` : ''}
+          </button>
+        </div>
       </div>
 
-      {/* JSON表示エリア (スクロール可能) */}
+      {/* コンテンツエリア */}
       <div className="json-viewer-container" ref={jsonViewerContainerRef}>
-        {tabData.jsonData ? (
-           // エラーオブジェクトかどうかの判定を改善
-           typeof tabData.jsonData === 'object' && tabData.jsonData !== null && 'error' in tabData.jsonData ? (
-                 <div className="center-panel error-panel">
-                    <p>エラー:</p>
-                    {/* エラー内容を安全に表示 */}
-                    <pre>{typeof tabData.jsonData.error === 'string' ? tabData.jsonData.error : JSON.stringify(tabData.jsonData.error)}</pre>
-                 </div>
-           ) : (
-                <div className="json-viewer">
-                    <Cell
-                        element={tabData.jsonData}
-                        searchQuery={tabData.searchQuery}
-                        searchResults={tabData.searchResults}
-                        currentResultIndex={tabData.currentResultIndex}
-                        path="" // Root path
-                        isRoot={true} // ルート要素はデフォルトで展開
-                        // searchInputRef は不要になった
-                    />
-                </div>
-           )
-        ) : tabData.filePath ? (
-            // filePathはあるがjsonDataがない場合（読み込み中など）
+        {tabData.viewMode === 'text' ? (
+          tabData.jsonData ? (
+            typeof tabData.jsonData === 'object' && tabData.jsonData !== null && 'error' in tabData.jsonData ? (
+              <div className="center-panel error-panel">
+                <p>エラー:</p>
+                <pre>{typeof tabData.jsonData.error === 'string' ? tabData.jsonData.error : JSON.stringify(tabData.jsonData.error)}</pre>
+              </div>
+            ) : (
+              <TextEditor tabData={tabData} onChange={onTextEditorChange || (() => {})} />
+            )
+          ) : (
             <div className="center-panel">
-                <p>{tabData.fileName} を読み込み中...</p>
+              <p>JSONファイルをドラッグ&ドロップしてください</p>
             </div>
-        ): (
-          // jsonDataもfilePathもない場合（例: 新規タブ）
-          <div className="center-panel">
-             <p>JSONファイルをドラッグ&ドロップしてください</p>
-          </div>
+          )
+        ) : (
+          tabData.jsonData ? (
+            typeof tabData.jsonData === 'object' && tabData.jsonData !== null && 'error' in tabData.jsonData ? (
+              <div className="center-panel error-panel">
+                <p>エラー:</p>
+                <pre>{typeof tabData.jsonData.error === 'string' ? tabData.jsonData.error : JSON.stringify(tabData.jsonData.error)}</pre>
+              </div>
+            ) : (
+              <div className="json-viewer">
+                <Cell
+                  element={tabData.jsonData}
+                  searchQuery={tabData.searchQuery}
+                  searchResults={tabData.searchResults}
+                  currentResultIndex={tabData.currentResultIndex}
+                  path=""
+                  isRoot={true}
+                  isEditMode={isEditMode}
+                  onDataChange={onDataChange}
+                  onDelete={onDelete}
+                />
+              </div>
+            )
+          ) : tabData.filePath ? (
+            <div className="center-panel">
+              <p>{tabData.fileName} を読み込み中...</p>
+            </div>
+          ) : (
+            <div className="center-panel">
+              <p>JSONファイルをドラッグ&ドロップしてください</p>
+            </div>
+          )
         )}
       </div>
     </div>

--- a/src/renderer/src/components/JsonView/JsonViewComponent.tsx
+++ b/src/renderer/src/components/JsonView/JsonViewComponent.tsx
@@ -6,6 +6,8 @@ import '../../App.css';
 
 interface JsonViewProps {
   tabData: TabState;
+  searchVisible: boolean;
+  onSearchVisibleChange: (visible: boolean) => void;
   onSearchInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onSearchKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   onSearchExecute: () => void;
@@ -16,8 +18,6 @@ interface JsonViewProps {
   onAddProperty?: (path: string, key: string, value: any) => void;
   onAddArrayItem?: (path: string, value: any) => void;
   onRenameKey?: (path: string, oldKey: string, newKey: string) => void;
-  onToggleEditMode?: () => void;
-  onToggleViewMode?: () => void;
   onSave?: () => void;
   onUndo?: () => void;
   onRedo?: () => void;
@@ -26,6 +26,8 @@ interface JsonViewProps {
 
 const JsonViewComponent: React.FC<JsonViewProps> = ({
   tabData,
+  searchVisible,
+  onSearchVisibleChange,
   onSearchInputChange,
   onSearchKeyDown,
   onSearchExecute,
@@ -36,8 +38,6 @@ const JsonViewComponent: React.FC<JsonViewProps> = ({
   onAddProperty,
   onAddArrayItem,
   onRenameKey,
-  onToggleEditMode,
-  onToggleViewMode,
   onSave,
   onUndo,
   onRedo,
@@ -93,75 +93,79 @@ const JsonViewComponent: React.FC<JsonViewProps> = ({
     }
   }, [tabData.searchQuery]);
 
+  useEffect(() => {
+    if (searchVisible && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [searchVisible]);
+
+  const handleCloseSearch = useCallback(() => {
+    onSearchVisibleChange(false);
+    onClearSearch();
+  }, [onSearchVisibleChange, onClearSearch]);
+
   const isEditMode = tabData.mode === 'edit';
 
   return (
     <div className="json-view-content">
-      {/* ツールバー */}
-      <div className="edit-toolbar">
-        <div className="toolbar-left">
-          <button
-            className={`toolbar-btn mode-btn ${isEditMode ? 'active' : ''}`}
-            onClick={onToggleEditMode}
-            title={isEditMode ? '閲覧モードに切替' : '編集モードに切替'}
-          >
-            {isEditMode ? '✏️ 編集中' : '👁 閲覧中'}
-          </button>
-          <button
-            className={`toolbar-btn view-btn ${tabData.viewMode === 'text' ? 'active' : ''}`}
-            onClick={onToggleViewMode}
-            title={tabData.viewMode === 'grid' ? 'テキスト表示' : 'グリッド表示'}
-          >
-            {tabData.viewMode === 'grid' ? '{ } テキスト' : '⚏ グリッド'}
-          </button>
-          {isEditMode && (
-            <>
-              <button className="toolbar-btn" onClick={onUndo} disabled={tabData.history.undo.length === 0} title="元に戻す (Ctrl+Z)">
-                ↶ 取消
-              </button>
-              <button className="toolbar-btn" onClick={onRedo} disabled={tabData.history.redo.length === 0} title="やり直し (Ctrl+Shift+Z)">
-                ↷ 再実行
-              </button>
-              <button className="toolbar-btn save-btn" onClick={onSave} disabled={!tabData.isDirty} title="保存 (Ctrl+S)">
-                💾 保存
-              </button>
-            </>
-          )}
-        </div>
-        {/* 検索バー */}
-        <div className="search-container">
-          <div className="search-input-wrapper">
-            <input
-              ref={searchInputRef}
-              type="text"
-              value={tabData.searchQuery}
-              onChange={onSearchInputChange}
-              onKeyDown={onSearchKeyDown}
-              placeholder="検索 (Enterで実行/次へ)"
-              disabled={!tabData.jsonData || tabData.jsonData.error}
-            />
-            {tabData.searchQuery && (
-              <button className="clear-search" onClick={onClearSearch} aria-label="Clear search"></button>
-            )}
-          </div>
-          <button onClick={onSearchExecute} disabled={!tabData.searchQuery || !tabData.jsonData || tabData.jsonData.error}>
-            検索
-          </button>
-          <button
-            onMouseDown={e => e.preventDefault()}
-            onClick={() => {
-              onNextResult();
-              searchInputRef.current?.focus();
-            }}
-            disabled={tabData.searchResults.length === 0}
-          >
-            次へ {tabData.searchResults.length > 0 ? `(${tabData.currentResultIndex + 1}/${tabData.searchResults.length})` : ''}
-          </button>
-        </div>
-      </div>
-
-      {/* コンテンツエリア */}
       <div className="json-viewer-container" ref={jsonViewerContainerRef}>
+
+        {searchVisible && (
+          <div className="search-overlay">
+            <div className="search-container">
+              <div className="search-input-wrapper">
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={tabData.searchQuery}
+                  onChange={onSearchInputChange}
+                  onKeyDown={(e) => {
+                    onSearchKeyDown(e);
+                    if (e.key === 'Escape') handleCloseSearch();
+                  }}
+                  placeholder="検索 (Enterで実行/次へ)"
+                  disabled={!tabData.jsonData || tabData.jsonData.error}
+                />
+                {tabData.searchQuery && (
+                  <button className="clear-search" onClick={onClearSearch} aria-label="Clear search"></button>
+                )}
+              </div>
+              <button className="search-nav-btn" onClick={onSearchExecute} disabled={!tabData.searchQuery || !tabData.jsonData || tabData.jsonData.error}>
+                検索
+              </button>
+              <button
+                className="search-nav-btn"
+                onMouseDown={e => e.preventDefault()}
+                onClick={() => {
+                  onNextResult();
+                  searchInputRef.current?.focus();
+                }}
+                disabled={tabData.searchResults.length === 0}
+              >
+                ▼ {tabData.searchResults.length > 0 ? `${tabData.currentResultIndex + 1}/${tabData.searchResults.length}` : ''}
+              </button>
+              <button className="search-close-btn" onClick={handleCloseSearch} title="閉じる (Esc)">
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M6 4.6L1.7.3.3 1.7 4.6 6 .3 10.3l1.4 1.4L6 7.4l4.3 4.3 1.4-1.4L7.4 6l4.3-4.3L10.3.3z"/></svg>
+              </button>
+            </div>
+          </div>
+        )}
+
+        {isEditMode && (
+          <div className="edit-actions-overlay">
+            <button className="floating-btn" onClick={onUndo} disabled={tabData.history.undo.length === 0} title="元に戻す (Ctrl+Z)">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M3.5 2v4.5H8l-1.6-1.6A3.5 3.5 0 0 1 12 8.5 3.5 3.5 0 0 1 6.4 10l-1.1 1.1A5 5 0 1 0 7.6 4.1L10 2H3.5z"/></svg>
+            </button>
+            <button className="floating-btn" onClick={onRedo} disabled={tabData.history.redo.length === 0} title="やり直し (Ctrl+Shift+Z)">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M12.5 2v4.5H8l1.6-1.6A3.5 3.5 0 0 0 4 8.5a3.5 3.5 0 0 0 5.6 1.5l1.1 1.1A5 5 0 1 1 8.4 4.1L6 2h6.5z"/></svg>
+            </button>
+            <span className="floating-separator" />
+            <button className="floating-btn save-btn" onClick={onSave} disabled={!tabData.isDirty} title="保存 (Ctrl+S)">
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M13.5 1h-12A1.5 1.5 0 0 0 0 2.5v11A1.5 1.5 0 0 0 1.5 15h12a1.5 1.5 0 0 0 1.5-1.5V5l-4-4zM5 2h4v3H5V2zm6 12H5v-4h6v4zm2-.5a.5.5 0 0 1-.5.5H12V9H4v5H2.5a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H4v4h6V2.5l3 3V13.5z"/></svg>
+            </button>
+          </div>
+        )}
+
         {tabData.viewMode === 'text' ? (
           tabData.jsonData ? (
             typeof tabData.jsonData === 'object' && tabData.jsonData !== null && 'error' in tabData.jsonData ? (

--- a/src/renderer/src/components/JsonView/TextEditor.tsx
+++ b/src/renderer/src/components/JsonView/TextEditor.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { TabState } from '../../App'
+import { serializeData, validateText } from '../Cell/FileUtils'
 
 interface TextEditorProps {
   tabData: TabState
@@ -15,7 +16,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
 
   useEffect(() => {
     if (tabData.jsonData !== null && tabData.jsonData !== undefined) {
-      const formatted = JSON.stringify(tabData.jsonData, null, 2)
+      const formatted = serializeData(tabData.jsonData, tabData.fileType)
       setText(formatted)
       setLineCount(formatted.split('\n').length)
       setError(null)
@@ -27,13 +28,13 @@ const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
     setText(newText)
     setLineCount(newText.split('\n').length)
     try {
-      JSON.parse(newText)
+      validateText(newText, tabData.fileType)
       setError(null)
       onChange(newText)
     } catch (err: any) {
       setError(err.message)
     }
-  }, [onChange])
+  }, [onChange, tabData.fileType])
 
   const handleScroll = useCallback(() => {
     if (textareaRef.current && lineNumbersRef.current) {
@@ -43,8 +44,8 @@ const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
 
   const handleFormat = useCallback(() => {
     try {
-      const parsed = JSON.parse(text)
-      const formatted = JSON.stringify(parsed, null, 2)
+      const parsed = validateText(text, tabData.fileType)
+      const formatted = serializeData(parsed, tabData.fileType)
       setText(formatted)
       setLineCount(formatted.split('\n').length)
       setError(null)
@@ -52,11 +53,11 @@ const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
     } catch (err: any) {
       setError(err.message)
     }
-  }, [text, onChange])
+  }, [text, onChange, tabData.fileType])
 
   const handleMinify = useCallback(() => {
     try {
-      const parsed = JSON.parse(text)
+      const parsed = validateText(text, tabData.fileType)
       const minified = JSON.stringify(parsed)
       setText(minified)
       setLineCount(1)
@@ -67,11 +68,15 @@ const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
     }
   }, [text, onChange])
 
+  const label = tabData.fileType === 'yaml' ? 'YAML' : 'JSON'
+
   return (
     <div className="text-editor-container">
       <div className="text-editor-toolbar">
         <button className="text-editor-btn" onClick={handleFormat}>フォーマット</button>
-        <button className="text-editor-btn" onClick={handleMinify}>最小化</button>
+        {tabData.fileType === 'json' && (
+          <button className="text-editor-btn" onClick={handleMinify}>最小化</button>
+        )}
       </div>
       <div className="text-editor-body">
         <div className="line-numbers" ref={lineNumbersRef}>
@@ -90,7 +95,7 @@ const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
       </div>
       {error && (
         <div className="text-editor-error">
-          <span>JSONパースエラー: {error}</span>
+          <span>{label}パースエラー: {error}</span>
         </div>
       )}
     </div>

--- a/src/renderer/src/components/JsonView/TextEditor.tsx
+++ b/src/renderer/src/components/JsonView/TextEditor.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import { TabState } from '../../App'
+
+interface TextEditorProps {
+  tabData: TabState
+  onChange: (newText: string) => void
+}
+
+const TextEditor: React.FC<TextEditorProps> = ({ tabData, onChange }) => {
+  const [text, setText] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [lineCount, setLineCount] = useState(1)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const lineNumbersRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (tabData.jsonData !== null && tabData.jsonData !== undefined) {
+      const formatted = JSON.stringify(tabData.jsonData, null, 2)
+      setText(formatted)
+      setLineCount(formatted.split('\n').length)
+      setError(null)
+    }
+  }, [tabData.id])
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newText = e.target.value
+    setText(newText)
+    setLineCount(newText.split('\n').length)
+    try {
+      JSON.parse(newText)
+      setError(null)
+      onChange(newText)
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }, [onChange])
+
+  const handleScroll = useCallback(() => {
+    if (textareaRef.current && lineNumbersRef.current) {
+      lineNumbersRef.current.scrollTop = textareaRef.current.scrollTop
+    }
+  }, [])
+
+  const handleFormat = useCallback(() => {
+    try {
+      const parsed = JSON.parse(text)
+      const formatted = JSON.stringify(parsed, null, 2)
+      setText(formatted)
+      setLineCount(formatted.split('\n').length)
+      setError(null)
+      onChange(formatted)
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }, [text, onChange])
+
+  const handleMinify = useCallback(() => {
+    try {
+      const parsed = JSON.parse(text)
+      const minified = JSON.stringify(parsed)
+      setText(minified)
+      setLineCount(1)
+      setError(null)
+      onChange(minified)
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }, [text, onChange])
+
+  return (
+    <div className="text-editor-container">
+      <div className="text-editor-toolbar">
+        <button className="text-editor-btn" onClick={handleFormat}>フォーマット</button>
+        <button className="text-editor-btn" onClick={handleMinify}>最小化</button>
+      </div>
+      <div className="text-editor-body">
+        <div className="line-numbers" ref={lineNumbersRef}>
+          {Array.from({ length: lineCount }, (_, i) => (
+            <div key={i} className="line-number">{i + 1}</div>
+          ))}
+        </div>
+        <textarea
+          ref={textareaRef}
+          className="text-editor-textarea"
+          value={text}
+          onChange={handleChange}
+          onScroll={handleScroll}
+          spellCheck={false}
+        />
+      </div>
+      {error && (
+        <div className="text-editor-error">
+          <span>JSONパースエラー: {error}</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default React.memo(TextEditor)

--- a/src/renderer/src/components/Tabs/TabsComponent.css
+++ b/src/renderer/src/components/Tabs/TabsComponent.css
@@ -4,12 +4,11 @@
 .tabs-container {
     width: 100%;
     background-color: var(--ev-c-black-mute);
-    /* 少し明るい背景 */
     padding: 5px 5px 0 5px;
-    /* 上左右に少しパディング、下はなし */
     box-sizing: border-box;
     flex-shrink: 0;
-    /* 高さが縮まないように */
+    display: flex;
+    align-items: flex-end;
 }
 
 .tabs-list {
@@ -18,25 +17,12 @@
     margin: 0;
     display: flex;
     flex-wrap: nowrap;
-    /* タブを折り返さない */
     overflow-x: auto;
-    /* 横スクロールを可能にする */
-    /* スクロールバーのスタイル（オプション） */
-    scrollbar-width: thin;
-    scrollbar-color: var(--ev-c-gray-1) var(--ev-c-black-mute);
+    scrollbar-width: none;
 }
 
 .tabs-list::-webkit-scrollbar {
-    height: 5px;
-}
-
-.tabs-list::-webkit-scrollbar-track {
-    background: var(--ev-c-black-mute);
-}
-
-.tabs-list::-webkit-scrollbar-thumb {
-    background-color: var(--ev-c-gray-1);
-    border-radius: 3px;
+    display: none;
 }
 
 
@@ -157,4 +143,36 @@
     background-color: var(--ev-c-gray-2);
     color: var(--ev-c-text-1);
     border-color: var(--ev-c-gray-1);
+}
+
+.tab-mode-buttons {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: auto;
+    padding-bottom: 4px;
+    flex-shrink: 0;
+}
+
+.tab-mode-btn {
+    padding: 4px 10px;
+    border: 1px solid var(--ev-c-gray-2);
+    border-radius: 3px;
+    background: var(--ev-c-gray-3);
+    color: var(--ev-c-text-2);
+    cursor: pointer;
+    font-size: 11px;
+    white-space: nowrap;
+    line-height: 1.3;
+}
+
+.tab-mode-btn:hover {
+    background: var(--ev-c-gray-2);
+    color: var(--ev-c-text-1);
+}
+
+.tab-mode-btn.active {
+    background: #094771;
+    border-color: #007acc;
+    color: var(--ev-c-text-1);
 }

--- a/src/renderer/src/components/Tabs/TabsComponent.tsx
+++ b/src/renderer/src/components/Tabs/TabsComponent.tsx
@@ -1,4 +1,3 @@
-// src/renderer/src/components/Tabs/TabsComponent.tsx
 import React from 'react';
 import './TabsComponent.css';
 
@@ -15,6 +14,10 @@ interface TabsProps {
   onSelectTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
   onAddTab: () => void;
+  onToggleEditMode?: () => void;
+  onToggleViewMode?: () => void;
+  activeTabMode?: string;
+  activeTabViewMode?: string;
 }
 
 const TabsComponent: React.FC<TabsProps> = ({
@@ -23,7 +26,13 @@ const TabsComponent: React.FC<TabsProps> = ({
   onSelectTab,
   onCloseTab,
   onAddTab,
+  onToggleEditMode,
+  onToggleViewMode,
+  activeTabMode = 'view',
+  activeTabViewMode = 'grid',
 }) => {
+  const isEditMode = activeTabMode === 'edit';
+
   return (
     <div className="tabs-container">
       <ul className="tabs-list">
@@ -56,6 +65,22 @@ const TabsComponent: React.FC<TabsProps> = ({
           <button className="add-tab-btn">+</button>
         </li>
       </ul>
+      <div className="tab-mode-buttons">
+        <button
+          className={`tab-mode-btn ${isEditMode ? 'active' : ''}`}
+          onClick={onToggleEditMode}
+          title={isEditMode ? '閲覧モードに切替' : '編集モードに切替'}
+        >
+          {isEditMode ? '✏️ 編集' : '👁 閲覧'}
+        </button>
+        <button
+          className={`tab-mode-btn ${activeTabViewMode === 'text' ? 'active' : ''}`}
+          onClick={onToggleViewMode}
+          title={activeTabViewMode === 'grid' ? 'テキスト表示' : 'グリッド表示'}
+        >
+          {activeTabViewMode === 'grid' ? '{ } テキスト' : '⚏ グリッド'}
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/renderer/src/components/Tabs/TabsComponent.tsx
+++ b/src/renderer/src/components/Tabs/TabsComponent.tsx
@@ -1,13 +1,12 @@
 // src/renderer/src/components/Tabs/TabsComponent.tsx
-// 新規作成
 import React from 'react';
-import './TabsComponent.css'; // スタイルファイル
+import './TabsComponent.css';
 
-// App.tsx からインポートするか、共通の型定義ファイルを作成する
 interface TabInfo {
   id: string;
-  fileName: string; // 表示名
+  fileName: string;
   filePath: string | null;
+  isDirty?: boolean;
 }
 
 interface TabsProps {
@@ -15,7 +14,7 @@ interface TabsProps {
   activeTabId: string | null;
   onSelectTab: (tabId: string) => void;
   onCloseTab: (tabId: string) => void;
-  onAddTab: () => void; // "+"ボタン用
+  onAddTab: () => void;
 }
 
 const TabsComponent: React.FC<TabsProps> = ({
@@ -33,28 +32,29 @@ const TabsComponent: React.FC<TabsProps> = ({
             key={tab.id}
             className={`tab-item ${tab.id === activeTabId ? 'active' : ''}`}
             onClick={() => onSelectTab(tab.id)}
-            title={tab.filePath || 'Untitled'} // フルパスをツールチップに表示
+            title={tab.filePath || 'Untitled'}
           >
-            <span className="tab-name">{tab.fileName}</span>
-            {/* 最後のタブ以外、またはタブが複数の場合に閉じるボタンを表示 */}
+            <span className="tab-name">
+              {tab.isDirty && <span className="dirty-marker">*</span>}
+              {tab.fileName}
+            </span>
             {(tabs.length > 1 || tab.filePath !== null) && (
-                 <button
-                    className="close-tab-btn"
-                    onClick={(e) => {
-                        e.stopPropagation(); // 親liのonClickイベントを発火させない
-                        onCloseTab(tab.id);
-                    }}
-                    aria-label={`Close tab ${tab.fileName}`}
-                 >
-                 ×
-                 </button>
+              <button
+                className="close-tab-btn"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCloseTab(tab.id);
+                }}
+                aria-label={`Close tab ${tab.fileName}`}
+              >
+                ×
+              </button>
             )}
           </li>
         ))}
-         {/* タブ追加ボタン */}
-         <li className="add-tab-item" onClick={onAddTab} title="New Tab">
-            <button className="add-tab-btn">+</button>
-         </li>
+        <li className="add-tab-item" onClick={onAddTab} title="New Tab">
+          <button className="add-tab-btn">+</button>
+        </li>
       </ul>
     </div>
   );

--- a/src/renderer/src/main.jsx
+++ b/src/renderer/src/main.jsx
@@ -8,5 +8,4 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>
-
 )

--- a/tests/fixtures/cloudformation.yaml
+++ b/tests/fixtures/cloudformation.yaml
@@ -1,0 +1,12 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  RegexPatternSet:
+    Type: AWS::WAFv2::RegexPatternSet
+    Properties:
+      RegularExpressionList:
+        - !Sub "^${PathPattern}*"
+      Scope: REGIONAL
+  MyBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref BucketNameParam

--- a/tests/fixtures/nsis-embedded.yaml
+++ b/tests/fixtures/nsis-embedded.yaml
@@ -1,0 +1,23 @@
+nsis:
+  script: |-
+    !include "StdUtils.nsh"
+    !macro _isUpdated _a _b _t _f
+      ${StdUtils.TestParameter} $R9 "updated"
+      StrCmp "$R9" "true" `${_t}` `${_f}`
+    !macroend
+    !define isUpdated `"" isUpdated ""`
+
+    !macro addLangs
+      !insertmacro MUI_LANGUAGE "English"
+      !insertmacro MUI_LANGUAGE "Japanese"
+    !macroend
+
+    !include "messages.nsh"
+    !addplugindir /x86-unicode "plugins\x86-unicode"
+
+    Var newStartMenuLink
+    Var oldStartMenuLink
+    Var newDesktopLink
+    Var oldDesktopLink
+
+    !include "common.nsh"

--- a/tests/fixtures/ruby-tags.yaml
+++ b/tests/fixtures/ruby-tags.yaml
@@ -1,0 +1,8 @@
+---
+- name: plain yaml
+  items:
+    - apple
+    - banana
+- ruby_obj: !ruby/object:MIME::Type
+    content-type: text/plain
+    encoding: base64

--- a/tests/yaml-parse.test.js
+++ b/tests/yaml-parse.test.js
@@ -1,0 +1,78 @@
+const yaml = require('js-yaml');
+const fs = require('fs');
+const path = require('path');
+
+const tolerantSchema = yaml.DEFAULT_SCHEMA.extend({
+  explicit: [
+    new yaml.Type('!', {
+      kind: 'scalar',
+      multi: true,
+      resolve: () => true,
+      construct: (data) => data ?? '',
+    }),
+    new yaml.Type('!', {
+      kind: 'mapping',
+      multi: true,
+      resolve: () => true,
+      construct: (data) => data ?? {},
+    }),
+    new yaml.Type('!', {
+      kind: 'sequence',
+      multi: true,
+      resolve: () => true,
+      construct: (data) => data ?? [],
+    }),
+  ],
+});
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+
+const cases = [
+  { file: 'nsis-embedded.yaml', key: 'nsis' },
+  { file: 'cloudformation.yaml', key: 'AWSTemplateFormatVersion' },
+  { file: 'ruby-tags.yaml', key: null },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const { file, key } of cases) {
+  const filePath = path.join(fixturesDir, file);
+  const raw = fs.readFileSync(filePath, 'utf8');
+  try {
+    const result = yaml.load(raw, { schema: tolerantSchema });
+    if (key && result[key] === undefined) {
+      console.log(`  FAIL: ${file} — missing key "${key}"`);
+      failed++;
+    } else {
+      console.log(`  PASS: ${file}`);
+      passed++;
+    }
+  } catch (e) {
+    console.log(`  FAIL: ${file} — ${e.message}`);
+    failed++;
+  }
+}
+
+const builderDebug = path.join(__dirname, '..', 'dist', 'builder-debug.yml');
+if (fs.existsSync(builderDebug)) {
+  const raw = fs.readFileSync(builderDebug, 'utf8');
+  try {
+    const result = yaml.load(raw, { schema: tolerantSchema });
+    if (result && result.nsis) {
+      console.log('  PASS: dist/builder-debug.yml');
+      passed++;
+    } else {
+      console.log('  FAIL: dist/builder-debug.yml — missing key "nsis"');
+      failed++;
+    }
+  } catch (e) {
+    console.log(`  FAIL: dist/builder-debug.yml — ${e.message}`);
+    failed++;
+  }
+} else {
+  console.log('  SKIP: dist/builder-debug.yml (not present)');
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## 改修概要
JSON 編集モード
- グリッドビューでのインライン値編集（ダブルクリック/F2）、キー編集、プロパティ・配列要素の追加・削除
- 閲覧/編集モード切替
- Undo/Redo（操作ログベース）、Ctrl+S 保存、未保存時の閉じる確認
テキストエディタ
- 行番号付きプレーンテキストエディタ、フォーマット/最小化、リアルタイムバリデーション
- グリッド/テキストビュー切替
検索機能
- Ctrl+F 検索バー、インクリメンタルサーチ、次/前ナビ、ハイライト
YAML 対応
- .yaml/.yml ファイルの開く・編集・保存
- js-yaml の multi Type 拡張スキーマで !Sub/!Ref/!ruby/object:... 等のカスタムタグを許容
- テストフィクスチャ 3件 + ビルド成果物でパース検証
UI
- 保存/Undo/Redo をフローティング SVG アイコン化
- 文字列値の改行を表示に反映、長い文字列の編集領域を表示サイズに合わせて確保